### PR TITLE
refactor: unify SAN JSON schema across Csr/Certificate (#33)

### DIFF
--- a/crates/pki-client/src/commands/convert.rs
+++ b/crates/pki-client/src/commands/convert.rs
@@ -234,7 +234,13 @@ fn convert_csr(data: &[u8], to: OutputFormat) -> Result<Vec<u8>> {
                 csr.signature_algorithm
             ));
             if !csr.san.is_empty() {
-                out.push_str(&format!("SANs: {}\n", csr.san.join(", ")));
+                let sans = csr
+                    .san
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                out.push_str(&format!("SANs: {sans}\n"));
             }
             Ok(out.into_bytes())
         }

--- a/crates/pki-client/src/commands/csr.rs
+++ b/crates/pki-client/src/commands/csr.rs
@@ -293,7 +293,7 @@ fn show(args: ShowArgs, config: &GlobalConfig) -> Result<CmdResult> {
         if !csr.san.is_empty() {
             println!("\n{}", "Subject Alternative Names:".bold().cyan());
             for san in &csr.san {
-                println!("  - {}", san.blue());
+                println!("  - {}", san.to_string().blue());
             }
         }
 

--- a/crates/pki-client/src/commands/diff.rs
+++ b/crates/pki-client/src/commands/diff.rs
@@ -173,8 +173,18 @@ fn print_csr_comparison(csr1: &Csr, csr2: &Csr, args: &DiffArgs) {
     println!();
 
     // SANs
-    let sans1 = csr1.san.join(", ");
-    let sans2 = csr2.san.join(", ");
+    let sans1 = csr1
+        .san
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sans2 = csr2
+        .san
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
     let (is_match, indicator) = compare_match(&sans1, &sans2);
     if is_match {
         matches += 1;

--- a/crates/pki-client/src/commands/show.rs
+++ b/crates/pki-client/src/commands/show.rs
@@ -361,7 +361,7 @@ fn show_csr(path: &Path, _config: &GlobalConfig) -> Result<()> {
         println!();
         println!("{}:", "Subject Alternative Names".cyan().bold());
         for san in &csr.san {
-            println!("    - {}", san.white());
+            println!("    - {}", san.to_string().white());
         }
     }
 

--- a/crates/pki-client/src/compat.rs
+++ b/crates/pki-client/src/compat.rs
@@ -1502,7 +1502,7 @@ pub struct Csr {
     pub key_algorithm: String,
     pub key_size: Option<u32>,
     pub signature_algorithm: String,
-    pub san: Vec<String>,
+    pub san: Vec<pki_client_output::SanEntry>,
     pub pem: String,
     der: Vec<u8>,
 }
@@ -1537,23 +1537,23 @@ impl Csr {
 
         // Extract SAN entries from the extensionRequest attribute (PKCS#10, RFC 2986).
         // Without this, `pki csr show` silently omits SANs even when present.
-        let mut san = Vec::new();
+        let mut san: Vec<pki_client_output::SanEntry> = Vec::new();
         if let Some(extensions) = csr.requested_extensions() {
             for ext in extensions {
                 if let x509_parser::extensions::ParsedExtension::SubjectAlternativeName(alt) = ext {
                     for gn in &alt.general_names {
                         match gn {
                             x509_parser::prelude::GeneralName::DNSName(v) => {
-                                san.push(format!("DNS:{v}"));
+                                san.push(pki_client_output::SanEntry::Dns((*v).to_string()));
                             }
                             x509_parser::prelude::GeneralName::RFC822Name(v) => {
-                                san.push(format!("email:{v}"));
+                                san.push(pki_client_output::SanEntry::Email((*v).to_string()));
                             }
                             x509_parser::prelude::GeneralName::IPAddress(bytes) => {
-                                san.push(format!("IP:{}", format_ip_bytes(bytes)));
+                                san.push(pki_client_output::SanEntry::Ip(format_ip_bytes(bytes)));
                             }
                             x509_parser::prelude::GeneralName::URI(v) => {
-                                san.push(format!("URI:{v}"));
+                                san.push(pki_client_output::SanEntry::Uri((*v).to_string()));
                             }
                             _ => {}
                         }
@@ -1785,12 +1785,23 @@ impl CsrBuilder {
             _ => format!("{}", algorithm),
         };
 
+        let mut san: Vec<pki_client_output::SanEntry> = Vec::new();
+        for v in &self.san_dns {
+            san.push(pki_client_output::SanEntry::Dns(v.clone()));
+        }
+        for v in &self.san_ip {
+            san.push(pki_client_output::SanEntry::Ip(v.clone()));
+        }
+        for v in &self.san_email {
+            san.push(pki_client_output::SanEntry::Email(v.clone()));
+        }
+
         Ok(Csr {
             subject: subject_str,
             key_algorithm: format!("{}", algorithm),
             key_size: Some(key.bits),
             signature_algorithm: sig_algo,
-            san: self.san_dns.clone(),
+            san,
             pem,
             der,
         })

--- a/crates/pki-client/src/deployer/backup.rs
+++ b/crates/pki-client/src/deployer/backup.rs
@@ -219,7 +219,7 @@ pub fn list_backups(backup_root: &Path) -> Result<Vec<BackupManifest>> {
     }
 
     // Sort newest first
-    backups.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    backups.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     Ok(backups)
 }
 

--- a/crates/pki-client/tests/cli_integration_tests.rs
+++ b/crates/pki-client/tests/cli_integration_tests.rs
@@ -305,6 +305,87 @@ fn test_csr_create_email_san_roundtrip() {
     );
 }
 
+/// Regression for #33: `pki csr show -f json` must emit typed SAN entries
+/// ({"Dns":"..."} / {"Email":"..."}) so JSON consumers can distinguish
+/// kinds without parsing the "DNS:" / "email:" prefix. This matches the
+/// schema already used by `pki cert show -f json`.
+#[test]
+fn test_csr_show_json_san_schema() {
+    if !binary_exists() {
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let key_path = temp_dir.path().join("schema.key");
+    let csr_path = temp_dir.path().join("schema.csr");
+
+    let _ = Command::new(pki_binary())
+        .args(["key", "gen", "ec", "--curve", "p256", "-o"])
+        .arg(&key_path)
+        .output()
+        .unwrap();
+
+    let create = Command::new(pki_binary())
+        .args([
+            "csr",
+            "create",
+            "--key",
+            key_path.to_str().unwrap(),
+            "--cn",
+            "schema.example.com",
+            "--san",
+            "dns:api.example.com",
+            "--san",
+            "email:admin@example.com",
+            "-o",
+        ])
+        .arg(&csr_path)
+        .output()
+        .expect("Failed to execute pki csr create");
+
+    if !create.status.success() {
+        let stderr = String::from_utf8_lossy(&create.stderr);
+        if stderr.contains("not yet implemented") {
+            return;
+        }
+    }
+    assert!(create.status.success(), "CSR creation failed: {create:?}");
+
+    let show = Command::new(pki_binary())
+        .args(["csr", "show", "-f", "json"])
+        .arg(&csr_path)
+        .output()
+        .expect("Failed to execute pki csr show -f json");
+    assert!(show.status.success(), "pki csr show -f json failed: {show:?}");
+    let stdout = String::from_utf8_lossy(&show.stdout);
+
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("not valid JSON: {e}\n{stdout}"));
+
+    let san = json.get("san").expect("json missing `san` field");
+    let arr = san.as_array().expect("`san` must be an array");
+    assert!(!arr.is_empty(), "san array empty: {stdout}");
+
+    let mut saw_dns = false;
+    let mut saw_email = false;
+    for entry in arr {
+        let obj = entry
+            .as_object()
+            .unwrap_or_else(|| panic!("san entry must be a typed object, got {entry}"));
+        if let Some(v) = obj.get("Dns") {
+            assert_eq!(v.as_str(), Some("api.example.com"));
+            saw_dns = true;
+        } else if let Some(v) = obj.get("Email") {
+            assert_eq!(v.as_str(), Some("admin@example.com"));
+            saw_email = true;
+        } else {
+            panic!("unexpected san variant: {entry}");
+        }
+    }
+    assert!(saw_dns, "Dns variant missing: {stdout}");
+    assert!(saw_email, "Email variant missing: {stdout}");
+}
+
 // ============================================================================
 // Format Conversion Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Csr::san and Certificate::san now both Vec<SanEntry>, so `pki csr show -f json` and `pki cert show -f json` emit the same typed schema (`{"Dns":"..."}`, `{"Email":"..."}`, `{"Ip":"..."}`, `{"Uri":"..."}`)
- Csr::from_der now populates typed SanEntry variants from GeneralName
- build_with_key merges dns/ip/email SAN arrays (belt-and-suspenders with #19)
- Pre-existing clippy unnecessary_sort_by fix in deployer/backup.rs piggy-backs

## Test plan
- [x] `cargo test --workspace --offline --lib` — 1505 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (default)
- [x] `cargo clippy --workspace --all-targets --features pqc -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --no-default-features --features fips -- -D warnings`
- [x] New TDD test `test_csr_show_json_san_schema` asserts typed JSON

Closes #33.

Generated with Claude Code