### PR TITLE
security: wrap SCEP/ACME secret material in Zeroizing (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "tracing",
  "url",
  "x509-parser 0.16.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/pki-client/Cargo.toml
+++ b/crates/pki-client/Cargo.toml
@@ -81,6 +81,9 @@ p12 = "0.6"
 # Logging
 tracing = "0.1"
 
+# Zeroize secret material on drop (private keys, challenge passwords)
+zeroize = { version = "1.8", features = ["derive"] }
+
 # POSIX constants (O_NOFOLLOW, ELOOP) for symlink-refusing file writes
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/pki-client/src/commands/acme/certonly.rs
+++ b/crates/pki-client/src/commands/acme/certonly.rs
@@ -237,7 +237,7 @@ pub(super) fn cmd_certonly(
     if !config.quiet {
         println!("Generating domain key and CSR...");
     }
-    let domain_key_pem = generate_domain_key()?;
+    let domain_key_pem = zeroize::Zeroizing::new(generate_domain_key()?);
     let csr_der = generate_csr_der(&domain_key_pem, domains)?;
 
     // Finalize order
@@ -268,7 +268,7 @@ pub(super) fn cmd_certonly(
     let key_file = cert_dir.join("privkey.pem");
 
     fs::write(&cert_file, &cert_pem)?;
-    crate::util::write_sensitive_file(&key_file, &domain_key_pem)?;
+    crate::util::write_sensitive_file(&key_file, domain_key_pem.as_bytes())?;
 
     // Save renewal configuration for automated renewals
     let mut renewal = RenewalConfig::new(

--- a/crates/pki-client/src/commands/scep.rs
+++ b/crates/pki-client/src/commands/scep.rs
@@ -459,7 +459,7 @@ fn enroll(
 
     let enroll_config = EnrollConfig {
         subject_cn: subject.to_string(),
-        challenge: challenge.map(|s| s.to_string()),
+        challenge: challenge.map(|s| zeroize::Zeroizing::new(s.to_string())),
         san_names: san_names.to_vec(),
         key_type,
         poll_interval_secs,
@@ -508,7 +508,7 @@ fn enroll(
                 }
                 if let Some(ref key) = response.private_key_pem {
                     warn_key_to_stdout();
-                    println!("{}", key);
+                    println!("{}", key.as_str());
                 }
             }
         }
@@ -536,7 +536,7 @@ fn save_enrollment_files(
 
     if let Some(ref key_pem) = response.private_key_pem {
         let key_path = dir.join(format!("{}-key.pem", base));
-        crate::util::write_sensitive_file(&key_path, key_pem)
+        crate::util::write_sensitive_file(&key_path, key_pem.as_bytes())
             .with_context(|| format!("Failed to write private key: {}", key_path.display()))?;
     }
 
@@ -599,9 +599,9 @@ mod tests {
             certificate: Some(
                 "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----".to_string(),
             ),
-            private_key_pem: Some(
+            private_key_pem: Some(zeroize::Zeroizing::new(
                 "-----BEGIN PRIVATE KEY-----\nMIIEv...\n-----END PRIVATE KEY-----".to_string(),
-            ),
+            )),
         }
     }
 

--- a/crates/pki-client/src/scep/client.rs
+++ b/crates/pki-client/src/scep/client.rs
@@ -294,7 +294,7 @@ impl ScepClient {
         // Step 3: Generate key pair, CSR, requester cert
         let material = build_message_material(
             &config.subject_cn,
-            config.challenge.as_deref(),
+            config.challenge.as_deref().map(|s| s.as_str()),
             config.key_type,
             &config.san_names,
         )
@@ -560,7 +560,7 @@ fn build_success_response(
         status: PkiStatus::Success,
         fail_info: None,
         certificate: cert_pem,
-        private_key_pem: Some(key_pem),
+        private_key_pem: Some(zeroize::Zeroizing::new(key_pem)),
     })
 }
 

--- a/crates/pki-client/src/scep/types.rs
+++ b/crates/pki-client/src/scep/types.rs
@@ -1,6 +1,7 @@
 //! SCEP Types and Constants
 
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 /// SCEP operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -215,10 +216,11 @@ pub struct EnrollmentResponse {
     pub fail_info: Option<FailInfo>,
     /// Issued certificate (PEM, if status is Success)
     pub certificate: Option<String>,
-    /// Private key PEM (generated during enrollment)
+    /// Private key PEM (generated during enrollment).
+    /// Wrapped in `Zeroizing` so the buffer is zeroed on drop.
     /// Never serialized — use enrollment_to_json() for safe JSON output.
-    #[serde(skip_serializing)]
-    pub private_key_pem: Option<String>,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub private_key_pem: Option<Zeroizing<String>>,
 }
 
 /// Configuration for SCEP enrollment.
@@ -226,8 +228,9 @@ pub struct EnrollmentResponse {
 pub struct EnrollConfig {
     /// Subject Common Name (CN)
     pub subject_cn: String,
-    /// Challenge password (optional)
-    pub challenge: Option<String>,
+    /// Challenge password (optional). Wrapped in `Zeroizing` so the buffer
+    /// is zeroed on drop even if enrollment panics or is cancelled.
+    pub challenge: Option<Zeroizing<String>>,
     /// Subject Alternative Names (DNS names)
     pub san_names: Vec<String>,
     /// Key type for enrollment
@@ -236,4 +239,22 @@ pub struct EnrollConfig {
     pub poll_interval_secs: u64,
     /// Maximum number of polling attempts
     pub max_polls: u32,
+}
+
+#[cfg(test)]
+mod zeroize_contract {
+    //! Compile-time proof that secret-bearing fields carry `Zeroizing`.
+    //!
+    //! These assertions fail to compile if a future refactor drops the
+    //! `Zeroizing<String>` wrapper on private key or challenge material.
+    use super::{EnrollConfig, EnrollmentResponse};
+    use zeroize::Zeroizing;
+
+    fn _assert_private_key_is_zeroizing(r: &EnrollmentResponse) -> &Option<Zeroizing<String>> {
+        &r.private_key_pem
+    }
+
+    fn _assert_challenge_is_zeroizing(c: &EnrollConfig) -> &Option<Zeroizing<String>> {
+        &c.challenge
+    }
 }

--- a/crates/pki-client/tests/cli_integration_tests.rs
+++ b/crates/pki-client/tests/cli_integration_tests.rs
@@ -356,11 +356,14 @@ fn test_csr_show_json_san_schema() {
         .arg(&csr_path)
         .output()
         .expect("Failed to execute pki csr show -f json");
-    assert!(show.status.success(), "pki csr show -f json failed: {show:?}");
+    assert!(
+        show.status.success(),
+        "pki csr show -f json failed: {show:?}"
+    );
     let stdout = String::from_utf8_lossy(&show.stdout);
 
-    let json: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("not valid JSON: {e}\n{stdout}"));
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not valid JSON: {e}\n{stdout}"));
 
     let san = json.get("san").expect("json missing `san` field");
     let arr = san.as_array().expect("`san` must be an array");


### PR DESCRIPTION
## Summary

Closes task #7 (P2 TDD: Expand Zeroizing coverage in commands).

Extends `zeroize::Zeroizing<T>` coverage to command-layer secret-bearing types so that SCEP/ACME private-key PEM and SCEP challenge-password bytes are zeroed on drop instead of lingering in heap buffers after the enrollment call returns.

### Scope

Audited `crates/pki-client/src/commands/{cert,scep,est}.rs` and `commands/acme/*` for raw `String` / `Vec<u8>` secret material.

Wrapped:

- `scep::types::EnrollmentResponse::private_key_pem` → `Option<Zeroizing<String>>`
- `scep::types::EnrollConfig::challenge` → `Option<Zeroizing<String>>`
- `commands::acme::certonly::certonly()`'s local `domain_key_pem` binding → `Zeroizing<String>`

Not wrapped (intentional):

- `commands::cert.rs` — holds no raw key material (dispatches to `pki p12 show`).
- `commands::est.rs` — HTTP Basic Auth passwords are still `Option<String>` from clap. Wrapping clap-derived fields requires a custom `value_parser` or a newtype with `FromStr`; deferred to a follow-up since EST passwords have a narrower exposure window (no cross-await-boundary retention) than the SCEP surface.

### Compile-time contract

Added `scep::types::zeroize_contract` test module — two type-checked assertion fns that reference the `Option<Zeroizing<String>>` shape directly. If a future refactor downgrades either field back to `Option<String>`, the module fails to compile. This is a type-level guarantee, not a runtime probabilistic test.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features pqc -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features fips -- -D warnings`
- [x] `cargo test --workspace --lib --offline` — 1505 passed, 0 failed
- [ ] CI green on PR

Generated with Claude Code