### PR TITLE
ci: make housekeeping issue-tracking steps non-blocking

### DIFF
--- a/.github/workflows/crypto-validation.yml
+++ b/.github/workflows/crypto-validation.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -99,6 +100,7 @@ jobs:
 
       - name: Close resolved issues
         if: success()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Close resolved issues
         if: success()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/scep-interop.yml
+++ b/.github/workflows/scep-interop.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -101,6 +102,7 @@ jobs:
 
       - name: Close resolved issues
         if: success()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to `Create issue on failure` and `Close resolved issues` steps in `crypto-validation`, `scep-interop`, `release-check` workflows.
- These steps call `gh` CLI which isn't installed on the self-hosted `pleb` runner — when routed there, real tests pass but the housekeeping step fails the job.
- Surfaced post-merge of #83 where Crypto Validation reported failure despite all test steps passing (only the `Close resolved issues` auto-close step exited 127).

## Test plan
- [x] YAML parse validation (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI runs green on this PR
- [ ] Re-run Crypto Validation on main post-merge succeeds even if housekeeping step fails

Related: #68 (runner infra — gh CLI missing on pleb)

Generated with Claude Code