### PR TITLE
chore(release): bump to v0.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Modern PKI CLI tool -- certificate inspection, key management, TLS probing, and enrollment protocols.
 
-**Version:** 0.8.0 | **Binary:** `pki` | **License:** Apache-2.0
+**Version:** 0.8.1 | **Binary:** `pki` | **License:** Apache-2.0
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "pki-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "pki-client-output"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "pki-hierarchy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "const-oid 0.9.6",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "pki-probe"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.88.0"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Pure Rust. No OpenSSL dependency. Human-friendly output. One binary, zero depend
 [![OpenSSL](https://img.shields.io/badge/OpenSSL-not%20required-brightgreen?logo=openssl&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client)
 
 <!-- Project Info -->
-[![Version](https://img.shields.io/badge/version-0.8.0-blue?logo=semver&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client/releases)
+[![Version](https://img.shields.io/badge/version-0.8.1-blue?logo=semver&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green?logo=apache&logoColor=white)](LICENSE)
 [![Rust](https://img.shields.io/badge/language-Rust-orange?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![MSRV](https://img.shields.io/badge/MSRV-1.88.0-orange?logo=rust&logoColor=white)](https://blog.rust-lang.org/)
@@ -263,7 +263,7 @@ curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/inst
 
 **Pin to a specific version:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash -s -- v0.8.0
+curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash -s -- v0.8.1
 ```
 
 > **Note:** `sudo` must be on `bash`, not `curl`. To install without sudo, set a writable directory: `INSTALL_DIR=~/.local/bin ... | bash`
@@ -271,7 +271,7 @@ curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/inst
 Or download manually from [GitHub Releases](https://github.com/rayketcham-lab/PKI-Client/releases):
 
 ```bash
-curl -fSL -o pki.tar.gz https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/pki-v0.8.0-x86_64-linux.tar.gz
+curl -fSL -o pki.tar.gz https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/pki-v0.8.1-x86_64-linux.tar.gz
 tar xzf pki.tar.gz
 sudo mv pki /usr/local/bin/
 ```
@@ -290,17 +290,17 @@ sha256sum -c SHA256SUMS.txt
 
 **GitHub attestation (SLSA provenance):**
 ```bash
-gh attestation verify pki-v0.8.0-x86_64-linux.tar.gz --repo rayketcham-lab/PKI-Client
+gh attestation verify pki-v0.8.1-x86_64-linux.tar.gz --repo rayketcham-lab/PKI-Client
 ```
 
 **Cosign signature (Sigstore):**
 ```bash
-curl -fSL -o pki.tar.gz.bundle https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/pki-v0.8.0-x86_64-linux.tar.gz.bundle
+curl -fSL -o pki.tar.gz.bundle https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/pki-v0.8.1-x86_64-linux.tar.gz.bundle
 cosign verify-blob \
-  --bundle pki-v0.8.0-x86_64-linux.tar.gz.bundle \
+  --bundle pki-v0.8.1-x86_64-linux.tar.gz.bundle \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
-  pki-v0.8.0-x86_64-linux.tar.gz
+  pki-v0.8.1-x86_64-linux.tar.gz
 ```
 
 ### Shell completions

--- a/docs/index.html
+++ b/docs/index.html
@@ -827,7 +827,7 @@ footer a:hover { color: var(--text); }
 <!-- Command Status -->
 <section class="section fade-up" id="status">
   <div class="section-inner">
-  <span class="section-tag">v0.8.0 Command Status</span>
+  <span class="section-tag">v0.8.1 Command Status</span>
   <h2>What Works</h2>
   <table class="command-table">
     <thead><tr><th>Command</th><th>Status</th><th>Notes</th></tr></thead>


### PR DESCRIPTION
## Summary
Patch release bumping workspace to **v0.8.1**. Covers all post-v0.8.0 fixes and security updates that have landed on main.

## Included commits (since v0.8.0 tag, 2026-04-16)
- `fix: RSA-3072 keygen + stale shell version assertion` (#83) — user-facing regression
- `security: wrap SCEP/ACME secret material in Zeroizing` (#81)
- `security: migrate rand 0.8 → 0.9` (#82) — CVE dep chain cleanup
- `ci: update runs-on labels from ubuntu3-runner to [self-hosted, Linux]` (#84)
- `ci: make housekeeping issue-tracking steps non-blocking` (#85)
- `ci: ignore RUSTSEC-2026-0097 (rand 0.9.2 custom-logger unsoundness)` (#86)

## Version bumps
- `Cargo.toml` workspace: 0.8.0 → 0.8.1 (propagates to all 4 crates + spork-core consumers)
- `README.md` version badge + install / verification examples
- `CLAUDE.md` version header
- `docs/index.html` Command Status tag

## Test plan
- [x] `cargo check --workspace` passes locally
- [ ] CI green on this PR
- [ ] After merge: tag `v0.8.1` on main to trigger release workflow (binary assets + SLSA attestation + Sigstore signature)

Generated with Claude Code