### PR TITLE
chore(release): v0.9.1 — ship .deb and .rpm installers

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -63,6 +63,18 @@ runs:
         cargo --version
         echo "::endgroup::"
 
+    - name: Detect runner glibc
+      id: glibc
+      shell: bash
+      run: |
+        # Scope the cargo cache per-glibc so a newer-glibc runner's target/
+        # (e.g. Ubuntu 24.04 w/ GLIBC 2.39) does not restore onto an older
+        # runner (Rocky 9 w/ GLIBC 2.34) where pre-linked test binaries fail
+        # with "GLIBC_2.39 not found".
+        v="$(ldd --version 2>&1 | head -n1 | awk '{print $NF}')"
+        echo "version=$v" >> "$GITHUB_OUTPUT"
+        echo "runner glibc: $v"
+
     - name: Cache cargo registry + build artifacts
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
       with:
@@ -72,15 +84,15 @@ runs:
           ~/.cargo/registry/cache
           ~/.cargo/git/db
           target
-        key: ${{ runner.os }}-cargo-${{ inputs.cache-prefix }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-glibc${{ steps.glibc.outputs.version }}-cargo-${{ inputs.cache-prefix }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-${{ inputs.cache-prefix }}-
+          ${{ runner.os }}-glibc${{ steps.glibc.outputs.version }}-cargo-${{ inputs.cache-prefix }}-
 
     - name: Clean stale aws-lc-sys build scripts
       shell: bash
       run: |
-        # aws-lc-sys build scripts cached from a runner with newer glibc (2.39)
-        # fail on Rocky Linux runners with GLIBC_2.39 not found. Force recompile.
+        # Belt-and-suspenders: even with glibc-scoped cache keys, nuke any
+        # aws-lc-sys build artifacts that might have slipped through.
         rm -rf target/debug/build/aws-lc-sys-* target/release/build/aws-lc-sys-* 2>/dev/null || true
 
     - name: Prune stale cargo caches

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -33,14 +33,33 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/rust-setup
         with:
-          cache-prefix: interop
-      - name: Build release binary
-        run: cargo build --release
+          targets: x86_64-unknown-linux-musl
+          cache-prefix: interop-musl
+      - name: Install musl toolchain
+        run: |
+          if ! command -v musl-gcc &> /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y musl-tools
+          fi
+      # Build musl-static so the artifact runs on any downstream runner regardless
+      # of glibc version. Previously shipped a glibc-dynamic binary that failed on
+      # Rocky runners with older libc (`GLIBC_2.38 not found`) — issue #68.
+      - name: Build release binary (musl static)
+        run: cargo build --release --target x86_64-unknown-linux-musl -p pki-client
+      - name: Verify static linking
+        run: |
+          if ldd target/x86_64-unknown-linux-musl/release/pki 2>&1 | grep -q "not a dynamic"; then
+            echo "OK: statically linked"
+          else
+            echo "ERROR: binary is not fully static"
+            ldd target/x86_64-unknown-linux-musl/release/pki
+            exit 1
+          fi
       - name: Upload binary
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
           name: pki-binary
-          path: target/release/pki
+          path: target/x86_64-unknown-linux-musl/release/pki
           retention-days: 1
 
   tls-probe:

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -48,11 +48,12 @@ jobs:
         run: cargo build --release --target x86_64-unknown-linux-musl -p pki-client
       - name: Verify static linking
         run: |
-          if ldd target/x86_64-unknown-linux-musl/release/pki 2>&1 | grep -q "not a dynamic"; then
+          ldd_out=$(ldd target/x86_64-unknown-linux-musl/release/pki 2>&1 || true)
+          if echo "$ldd_out" | grep -Eq "statically linked|not a dynamic"; then
             echo "OK: statically linked"
           else
             echo "ERROR: binary is not fully static"
-            ldd target/x86_64-unknown-linux-musl/release/pki
+            echo "$ldd_out"
             exit 1
           fi
       - name: Upload binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ env:
 
 jobs:
   build-linux:
-    name: Build Linux (static musl)
+    name: Build Linux installers (.deb + .rpm)
     # Pinned to ubuntu3-runner: musl-tools not available on Rocky Linux
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -30,8 +30,16 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y musl-tools
           fi
+      - name: Install cargo-deb and cargo-generate-rpm
+        run: |
+          if ! command -v cargo-deb &> /dev/null; then
+            cargo install --locked cargo-deb@2.7.0
+          fi
+          if ! command -v cargo-generate-rpm &> /dev/null; then
+            cargo install --locked cargo-generate-rpm@0.14.1
+          fi
       - name: Build static binary (with PQC support)
-        run: cargo build --release --features pqc --target x86_64-unknown-linux-musl
+        run: cargo build --release --features pqc --target x86_64-unknown-linux-musl -p pki-client
       - name: Strip binary
         run: strip target/x86_64-unknown-linux-musl/release/pki
       - name: Verify static linking
@@ -39,19 +47,56 @@ jobs:
           if ldd target/x86_64-unknown-linux-musl/release/pki 2>&1 | grep -q "not a dynamic"; then
             echo "OK: statically linked"
           else
-            echo "WARN: may not be fully static"
+            echo "ERROR: binary is not fully static"
+            ldd target/x86_64-unknown-linux-musl/release/pki
+            exit 1
           fi
           ls -lh target/x86_64-unknown-linux-musl/release/pki
-      - name: Package
+
+      # ── Build .deb installer ──────────────────────────────────────
+      - name: Build .deb installer
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          cd target/x86_64-unknown-linux-musl/release
-          tar czf "../../../pki-${TAG_NAME}-x86_64-linux.tar.gz" pki
+          VERSION="${TAG_NAME#v}"
+          cargo deb --no-build --no-strip \
+            --target x86_64-unknown-linux-musl \
+            -p pki-client \
+            --output "pki-client_${VERSION}_amd64.deb"
+          ls -lh pki-client_*.deb
+
+      # ── Build .rpm installer ──────────────────────────────────────
+      - name: Build .rpm installer
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          cargo generate-rpm \
+            --target x86_64-unknown-linux-musl \
+            -p crates/pki-client \
+            --output "pki-client-${VERSION}-1.x86_64.rpm"
+          ls -lh pki-client-*.rpm
+
+      # ── Smoke-test installers ─────────────────────────────────────
+      - name: Smoke-test .deb (dpkg-deb inspection)
+        run: |
+          dpkg-deb --info pki-client_*.deb
+          dpkg-deb --contents pki-client_*.deb
+      - name: Smoke-test .rpm (rpm inspection)
+        run: |
+          if command -v rpm &> /dev/null; then
+            rpm -qip pki-client-*.rpm
+            rpm -qlp pki-client-*.rpm
+          else
+            echo "rpm not installed on runner — skipping inspection"
+          fi
+
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
-          name: pki-linux
-          path: pki-*.tar.gz
+          name: pki-linux-installers
+          path: |
+            pki-client_*.deb
+            pki-client-*.rpm
 
   sign-and-release:
     name: Sign and Release
@@ -87,13 +132,17 @@ jobs:
             fi
           fi
       - name: Generate checksums
-        run: sha256sum pki-*.tar.gz > SHA256SUMS.txt
+        run: sha256sum pki-client_*.deb pki-client-*.rpm > SHA256SUMS.txt
 
       # --- Supply chain security: SLSA provenance ---
-      - name: Attest build provenance (tarball)
+      - name: Attest build provenance (.deb)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
-          subject-path: pki-*.tar.gz
+          subject-path: pki-client_*.deb
+      - name: Attest build provenance (.rpm)
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: pki-client-*.rpm
       - name: Attest build provenance (checksums)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
@@ -102,9 +151,9 @@ jobs:
       # --- Supply chain security: Sigstore cosign signing ---
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
-      - name: Sign artifacts with cosign (keyless)
+      - name: Sign installers with cosign (keyless)
         run: |
-          for f in pki-*.tar.gz SHA256SUMS.txt; do
+          for f in pki-client_*.deb pki-client-*.rpm SHA256SUMS.txt; do
             cosign sign-blob --yes --bundle "${f}.bundle" "$f"
           done
 
@@ -116,4 +165,4 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --generate-notes \
-            pki-*.tar.gz SHA256SUMS.txt *.bundle
+            pki-client_*.deb pki-client-*.rpm SHA256SUMS.txt *.bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,12 @@ jobs:
         run: strip target/x86_64-unknown-linux-musl/release/pki
       - name: Verify static linking
         run: |
-          if ldd target/x86_64-unknown-linux-musl/release/pki 2>&1 | grep -q "not a dynamic"; then
+          ldd_out=$(ldd target/x86_64-unknown-linux-musl/release/pki 2>&1 || true)
+          if echo "$ldd_out" | grep -Eq "statically linked|not a dynamic"; then
             echo "OK: statically linked"
           else
             echo "ERROR: binary is not fully static"
-            ldd target/x86_64-unknown-linux-musl/release/pki
+            echo "$ldd_out"
             exit 1
           fi
           ls -lh target/x86_64-unknown-linux-musl/release/pki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-19
+
+### Changed
+
+- **Release artifacts are now native Linux installers (`.deb` + `.rpm`)** instead of raw `tar.gz` tarballs. Installers ship the statically-linked musl binary, register with the host package manager (`dpkg`/`rpm`), and install `pki` to `/usr/bin/pki`. `apt remove pki-client` / `dnf remove pki-client` now work cleanly.
+- `install.sh` detects the host package format (`dpkg` or `rpm`) and installs the matching installer via the native package manager.
+- `README.md` install section rewritten to document the new `.deb`/`.rpm` flow.
+- `.github/workflows/release.yml` rewritten to build both installers via `cargo-deb` and `cargo-generate-rpm`, smoke-test them with `dpkg-deb`/`rpm -qip`, and sign each package artifact with Sigstore cosign + SLSA provenance.
+
+### Added
+
+- `[package.metadata.deb]` and `[package.metadata.generate-rpm]` sections on `crates/pki-client/Cargo.toml` — drive installer generation with full license-file, extended-description, and doc-file packaging.
+
+### Notes
+
+- v0.9.1 is a **packaging-only** release on top of v0.9.0. No code changes; the binary inside the installer is byte-identical to the `v0.9.0` musl build.
+- If you prefer a raw static binary, extract it from the installer: `dpkg-deb -x pki-client_0.9.1_amd64.deb out/` or `rpm2cpio pki-client-0.9.1-1.x86_64.rpm | cpio -idmv`.
+
 ## [0.9.0] - 2026-04-19
 
 ### BREAKING CHANGES

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Modern PKI CLI tool -- certificate inspection, key management, TLS probing, compliance validation, DANE, chain building.
 
-**Version:** 0.9.0 | **Binary:** `pki` | **License:** Apache-2.0
+**Version:** 0.9.1 | **Binary:** `pki` | **License:** Apache-2.0
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "pki-client"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "pki-client-output"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pki-hierarchy"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "const-oid 0.9.6",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "pki-probe"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.88.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pure Rust. No OpenSSL dependency. Human-friendly output. One static binary (musl
 [![OpenSSL](https://img.shields.io/badge/OpenSSL-not%20required-brightgreen?logo=openssl&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client)
 
 <!-- Project Info -->
-[![Version](https://img.shields.io/badge/version-0.9.0-blue?logo=semver&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client/releases)
+[![Version](https://img.shields.io/badge/version-0.9.1-blue?logo=semver&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green?logo=apache&logoColor=white)](LICENSE)
 [![Rust](https://img.shields.io/badge/language-Rust-orange?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![MSRV](https://img.shields.io/badge/MSRV-1.88.0-orange?logo=rust&logoColor=white)](https://blog.rust-lang.org/)
@@ -236,65 +236,86 @@ Certificate:
 
 ## Install
 
-### Pre-built binaries (recommended)
+`pki-client` ships as native Linux installers — `.deb` for Debian/Ubuntu and `.rpm` for RHEL/Fedora/Rocky/Alma. The binary is statically linked against musl libc — zero runtime dependencies. Installers deploy `pki` to `/usr/bin/pki` with appropriate permissions and register with the distro's package manager so `apt remove` / `dnf remove` work as expected.
 
-Download a static binary — no Rust, no build tools, no dependencies:
-
-**Install** (requires sudo for `/usr/local/bin`):
-```bash
-curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash
-```
-
-**Upgrade:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash -s -- upgrade
-```
-
-**Uninstall:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash -s -- uninstall
-```
-
-**Pin to a specific version:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash -s -- v0.9.0
-```
-
-> **Note:** `sudo` must be on `bash`, not `curl`. To install without sudo, set a writable directory: `INSTALL_DIR=~/.local/bin ... | bash`
-
-Or download manually from [GitHub Releases](https://github.com/rayketcham-lab/PKI-Client/releases):
+### Debian / Ubuntu (.deb)
 
 ```bash
-curl -fSL -o pki.tar.gz https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/pki-v0.9.0-x86_64-linux.tar.gz
-tar xzf pki.tar.gz
-sudo mv pki /usr/local/bin/
+# Download installer + signatures
+VERSION=v0.9.1
+curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client_${VERSION#v}_amd64.deb
+curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client_${VERSION#v}_amd64.deb.bundle
+
+# (optional) Verify signature — see "Verify release integrity" below
+cosign verify-blob \
+  --bundle pki-client_${VERSION#v}_amd64.deb.bundle \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
+  pki-client_${VERSION#v}_amd64.deb
+
+# Install
+sudo dpkg -i pki-client_${VERSION#v}_amd64.deb
+
+# Verify
+pki --version
 ```
 
-**Platform:** x86_64 Linux. The binary is statically linked (musl) — zero runtime dependencies.
+**Upgrade / reinstall:** `sudo dpkg -i pki-client_*.deb` (overwrites in place)
+**Uninstall:** `sudo apt remove pki-client`
+
+### RHEL / Fedora / Rocky / Alma (.rpm)
+
+```bash
+# Download installer + signatures
+VERSION=v0.9.1
+curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client-${VERSION#v}-1.x86_64.rpm
+curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client-${VERSION#v}-1.x86_64.rpm.bundle
+
+# (optional) Verify signature — see "Verify release integrity" below
+cosign verify-blob \
+  --bundle pki-client-${VERSION#v}-1.x86_64.rpm.bundle \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
+  pki-client-${VERSION#v}-1.x86_64.rpm
+
+# Install (dnf/yum auto-resolves no deps — binary is static)
+sudo dnf install -y ./pki-client-${VERSION#v}-1.x86_64.rpm
+
+# Verify
+pki --version
+```
+
+**Upgrade:** `sudo dnf upgrade ./pki-client-*.rpm`
+**Uninstall:** `sudo dnf remove pki-client`
+
+**Platform:** x86_64 Linux. The binary is statically linked (musl) — zero runtime dependencies, installs cleanly on any glibc or musl host.
+
+Browse all assets at [GitHub Releases](https://github.com/rayketcham-lab/PKI-Client/releases).
 
 ### Verify release integrity
 
-Every release includes SHA256 checksums, [SLSA build provenance](https://slsa.dev/), and [Sigstore](https://www.sigstore.dev/) cosign signatures. All artifacts are built by GitHub Actions from source — no human touches the binary.
+Every release ships with SHA256 checksums, [SLSA build provenance](https://slsa.dev/), and [Sigstore](https://www.sigstore.dev/) cosign signatures. All installers are built by GitHub Actions directly from tagged source — no human touches the binary.
 
 **SHA256 checksum:**
 ```bash
 curl -fSL -o SHA256SUMS.txt https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/SHA256SUMS.txt
-sha256sum -c SHA256SUMS.txt
+sha256sum -c --ignore-missing SHA256SUMS.txt
 ```
 
 **GitHub attestation (SLSA provenance):**
 ```bash
-gh attestation verify pki-v0.9.0-x86_64-linux.tar.gz --repo rayketcham-lab/PKI-Client
+gh attestation verify pki-client_0.9.1_amd64.deb --repo rayketcham-lab/PKI-Client
+gh attestation verify pki-client-0.9.1-1.x86_64.rpm --repo rayketcham-lab/PKI-Client
 ```
 
-**Cosign signature (Sigstore):**
+**Cosign signature (Sigstore keyless):**
 ```bash
-curl -fSL -o pki.tar.gz.bundle https://github.com/rayketcham-lab/PKI-Client/releases/latest/download/pki-v0.9.0-x86_64-linux.tar.gz.bundle
+# .deb example (see per-distro sections above for inline usage)
 cosign verify-blob \
-  --bundle pki-v0.9.0-x86_64-linux.tar.gz.bundle \
+  --bundle pki-client_0.9.1_amd64.deb.bundle \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
-  pki-v0.9.0-x86_64-linux.tar.gz
+  pki-client_0.9.1_amd64.deb
 ```
 
 ### Shell completions

--- a/crates/pki-client/Cargo.toml
+++ b/crates/pki-client/Cargo.toml
@@ -78,18 +78,36 @@ const-oid = "0.9"
 der = { workspace = true }
 
 # ── Linux package metadata ──────────────────────────────────────────
+# Both packages ship the statically-linked musl binary — zero runtime deps.
+# Build with: cargo build --release --features pqc --target x86_64-unknown-linux-musl
+# Package with:
+#   cargo deb --no-build --target x86_64-unknown-linux-musl -p pki-client
+#   cargo generate-rpm --target x86_64-unknown-linux-musl -p crates/pki-client
 
 [package.metadata.deb]
 name = "pki-client"
-maintainer = "Ray Ketcham <ray@rayketcham.com>"
+maintainer = "Ray Ketcham <rayketcham@ogjos.com>"
+copyright = "2026, Ray Ketcham <rayketcham@ogjos.com>"
+license-file = ["../../LICENSE", "0"]
+extended-description = """\
+Modern PKI CLI tool — certificate inspection, key management, TLS probing, \
+compliance validation, DANE, and chain building. Pure Rust, no OpenSSL \
+dependency. Statically linked with musl — zero runtime dependencies."""
 section = "utils"
 priority = "optional"
-depends = "libc6"
+depends = ""
 assets = [
-    ["target/release/pki", "usr/bin/", "755"],
+    ["target/x86_64-unknown-linux-musl/release/pki", "usr/bin/", "755"],
+    ["../../README.md", "usr/share/doc/pki-client/README.md", "644"],
+    ["../../LICENSE", "usr/share/doc/pki-client/LICENSE", "644"],
 ]
 
 [package.metadata.generate-rpm]
+name = "pki-client"
+summary = "Modern PKI CLI — cert inspection, key management, TLS probing"
+license = "Apache-2.0"
 assets = [
     { source = "target/x86_64-unknown-linux-musl/release/pki", dest = "/usr/bin/pki", mode = "755" },
+    { source = "README.md", dest = "/usr/share/doc/pki-client/README.md", mode = "644", doc = true },
+    { source = "LICENSE", dest = "/usr/share/doc/pki-client/LICENSE", mode = "644", doc = true },
 ]

--- a/install.sh
+++ b/install.sh
@@ -4,15 +4,32 @@ set -euo pipefail
 # ============================================================================
 # PKI-Client Installer / Upgrader / Uninstaller
 #
-# Install:    curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | bash
-# Upgrade:    curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | bash -s -- upgrade
-# Uninstall:  curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | bash -s -- uninstall
-# Pin version: curl -fsSL ... | bash -s -- v0.8.0
+# Detects the host distro and installs the appropriate native package:
+#   Debian/Ubuntu  -> .deb  (installed with dpkg)
+#   RHEL/Fedora/etc -> .rpm (installed with dnf/yum)
+#
+# Install:     curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash
+# Upgrade:     curl -fsSL .../install.sh | sudo bash -s -- upgrade
+# Uninstall:   curl -fsSL .../install.sh | sudo bash -s -- uninstall
+# Pin version: curl -fsSL .../install.sh | sudo bash -s -- v0.9.1
 # ============================================================================
 
 REPO="rayketcham-lab/PKI-Client"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 ACTION="${1:-install}"
+
+# ── Detect package format ────────────────────────────────────────────────────
+
+detect_pkg_format() {
+    if command -v dpkg >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+        echo "deb"
+    elif command -v rpm >/dev/null 2>&1 && (command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1); then
+        echo "rpm"
+    else
+        echo "unsupported"
+    fi
+}
+
+PKG_FORMAT="$(detect_pkg_format)"
 
 # ── Uninstall ────────────────────────────────────────────────────────────────
 
@@ -20,112 +37,101 @@ if [[ "$ACTION" == "uninstall" ]]; then
     echo "PKI-Client Uninstaller"
     echo "======================"
 
-    if [[ ! -f "$INSTALL_DIR/pki" ]]; then
-        echo "pki is not installed at $INSTALL_DIR/pki"
-        exit 0
-    fi
-
-    CURRENT=$("$INSTALL_DIR/pki" --version 2>/dev/null || echo "unknown")
-    echo "Removing: $CURRENT"
-    echo "Location: $INSTALL_DIR/pki"
-
-    if rm -f "$INSTALL_DIR/pki" 2>/dev/null; then
-        true
-    elif sudo rm -f "$INSTALL_DIR/pki" 2>/dev/null; then
-        true
-    else
-        echo "ERROR: Cannot remove $INSTALL_DIR/pki — try: sudo bash -s -- uninstall"
-        exit 1
-    fi
+    case "$PKG_FORMAT" in
+        deb)
+            if dpkg -s pki-client >/dev/null 2>&1; then
+                apt-get remove -y pki-client
+            else
+                echo "pki-client is not installed (dpkg)."
+            fi
+            ;;
+        rpm)
+            if rpm -q pki-client >/dev/null 2>&1; then
+                if command -v dnf >/dev/null 2>&1; then
+                    dnf remove -y pki-client
+                else
+                    yum remove -y pki-client
+                fi
+            else
+                echo "pki-client is not installed (rpm)."
+            fi
+            ;;
+        *)
+            echo "ERROR: Unsupported distro — no dpkg or rpm detected."
+            exit 1
+            ;;
+    esac
 
     echo ""
-    echo "Done! pki has been uninstalled."
+    echo "Done! pki-client has been uninstalled."
     exit 0
 fi
 
-# ── Upgrade detection ────────────────────────────────────────────────────────
+# ── Install / Upgrade ────────────────────────────────────────────────────────
 
 echo "PKI-Client Installer"
 echo "===================="
 
-# Detect platform
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
+# Platform check
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
 
-case "$OS" in
-    linux)  PLATFORM="x86_64-linux" ;;
-    *)
-        echo "ERROR: Unsupported OS: $OS"
-        echo "Pre-built binaries are available for Linux x86_64 only."
-        exit 1
-        ;;
-esac
+if [[ "$OS" != "linux" ]]; then
+    echo "ERROR: Unsupported OS: $OS (Linux only for pre-built installers)"
+    exit 1
+fi
 
 case "$ARCH" in
-    x86_64|amd64) ;; # supported
+    x86_64|amd64) ;;
     *)
-        echo "ERROR: Unsupported architecture: $ARCH"
-        echo "Pre-built binaries are available for x86_64 only."
+        echo "ERROR: Unsupported architecture: $ARCH (x86_64 only)"
         exit 1
         ;;
 esac
 
+if [[ "$PKG_FORMAT" == "unsupported" ]]; then
+    echo "ERROR: No supported package manager found."
+    echo "Supported: dpkg+apt (Debian/Ubuntu) or rpm+dnf/yum (RHEL/Fedora/Rocky/Alma)."
+    echo "Download assets manually from: https://github.com/$REPO/releases"
+    exit 1
+fi
+
 # Resolve version
-if [[ "$ACTION" == "upgrade" ]] || [[ "$ACTION" == "install" ]]; then
+if [[ "$ACTION" == "upgrade" || "$ACTION" == "install" ]]; then
     VERSION="latest"
-elif [[ "$ACTION" == v* ]]; then
-    # User passed a version tag directly (e.g., v0.5.0-beta.4)
-    VERSION="$ACTION"
 else
     VERSION="$ACTION"
 fi
 
 if [[ "$VERSION" == "latest" ]]; then
-    echo "Fetching latest release..."
-    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+    echo "Fetching latest release tag..."
+    VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)"
     if [[ -z "$VERSION" ]]; then
         echo "ERROR: Could not determine latest version."
-        echo "Download manually from: https://github.com/$REPO/releases"
         exit 1
     fi
 fi
 
-# Check if already installed and up to date
-CURRENT_VERSION=""
-if [[ -f "$INSTALL_DIR/pki" ]]; then
-    CURRENT_VERSION=$("$INSTALL_DIR/pki" --version 2>/dev/null | awk '{print $2}' || echo "")
-    LATEST_CLEAN="${VERSION#v}"  # strip leading 'v'
+VERSION_NUM="${VERSION#v}"
 
-    if [[ "$CURRENT_VERSION" == "$LATEST_CLEAN" ]]; then
-        echo "Already up to date: pki $CURRENT_VERSION"
-        exit 0
-    fi
+case "$PKG_FORMAT" in
+    deb) FILENAME="pki-client_${VERSION_NUM}_amd64.deb" ;;
+    rpm) FILENAME="pki-client-${VERSION_NUM}-1.x86_64.rpm" ;;
+esac
 
-    if [[ -n "$CURRENT_VERSION" ]]; then
-        echo "Upgrade:  $CURRENT_VERSION -> $LATEST_CLEAN"
-    fi
-else
-    echo "Fresh install"
-fi
+URL="https://github.com/$REPO/releases/download/${VERSION}/${FILENAME}"
+CHECKSUM_URL="https://github.com/$REPO/releases/download/${VERSION}/SHA256SUMS.txt"
 
 echo "Version:  $VERSION"
-echo "Platform: $PLATFORM"
-echo "Install:  $INSTALL_DIR/pki"
+echo "Package:  $FILENAME ($PKG_FORMAT)"
 echo ""
 
-# ── Download ─────────────────────────────────────────────────────────────────
-
-FILENAME="pki-${VERSION}-${PLATFORM}.tar.gz"
-URL="https://github.com/$REPO/releases/download/$VERSION/$FILENAME"
-CHECKSUM_URL="https://github.com/$REPO/releases/download/$VERSION/SHA256SUMS.txt"
-
-TMPDIR=$(mktemp -d)
+TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 echo "Downloading $FILENAME..."
 if ! curl -fSL -o "$TMPDIR/$FILENAME" "$URL"; then
-    echo "ERROR: Download failed."
-    echo "Check available releases: https://github.com/$REPO/releases"
+    echo "ERROR: Download failed from $URL"
     exit 1
 fi
 
@@ -134,8 +140,8 @@ fi
 echo "Verifying checksum..."
 curl -fsSL -o "$TMPDIR/SHA256SUMS.txt" "$CHECKSUM_URL" 2>/dev/null || true
 if [[ -f "$TMPDIR/SHA256SUMS.txt" ]]; then
-    EXPECTED=$(grep "$FILENAME" "$TMPDIR/SHA256SUMS.txt" | cut -d' ' -f1)
-    ACTUAL=$(sha256sum "$TMPDIR/$FILENAME" | cut -d' ' -f1)
+    EXPECTED="$(grep "$FILENAME" "$TMPDIR/SHA256SUMS.txt" | cut -d' ' -f1)"
+    ACTUAL="$(sha256sum "$TMPDIR/$FILENAME" | cut -d' ' -f1)"
     if [[ "$EXPECTED" == "$ACTUAL" ]]; then
         echo "Checksum: OK"
     else
@@ -148,26 +154,25 @@ else
     echo "Checksum: skipped (no SHA256SUMS.txt)"
 fi
 
-# ── Extract and install ──────────────────────────────────────────────────────
+# ── Install ──────────────────────────────────────────────────────────────────
 
-echo "Installing to $INSTALL_DIR..."
-tar xzf "$TMPDIR/$FILENAME" -C "$TMPDIR"
-
-if mv "$TMPDIR/pki" "$INSTALL_DIR/pki" 2>/dev/null; then
-    true
-elif sudo mv "$TMPDIR/pki" "$INSTALL_DIR/pki" 2>/dev/null; then
-    true
-else
-    echo "ERROR: Cannot install to $INSTALL_DIR — try: sudo bash"
-    exit 1
-fi
-chmod +x "$INSTALL_DIR/pki" 2>/dev/null || sudo chmod +x "$INSTALL_DIR/pki"
+echo "Installing $FILENAME..."
+case "$PKG_FORMAT" in
+    deb)
+        dpkg -i "$TMPDIR/$FILENAME" || {
+            echo "dpkg reported unmet deps — attempting apt-get -f install"
+            apt-get install -f -y
+        }
+        ;;
+    rpm)
+        if command -v dnf >/dev/null 2>&1; then
+            dnf install -y "$TMPDIR/$FILENAME"
+        else
+            yum install -y "$TMPDIR/$FILENAME"
+        fi
+        ;;
+esac
 
 echo ""
-if [[ -n "$CURRENT_VERSION" ]]; then
-    echo "Done! Upgraded pki $CURRENT_VERSION -> $VERSION at $INSTALL_DIR/pki"
-else
-    echo "Done! Installed pki $VERSION to $INSTALL_DIR/pki"
-fi
-echo ""
-"$INSTALL_DIR/pki" --version 2>/dev/null || true
+echo "Done! Installed pki-client $VERSION"
+pki --version 2>/dev/null || echo "(pki binary not yet on PATH in this shell; open a new shell or check /usr/bin/pki)"


### PR DESCRIPTION
## Summary

- Release artifacts are now native Linux installers (`.deb` for Debian/Ubuntu, `.rpm` for RHEL/Fedora/Rocky/Alma) instead of raw `tar.gz` tarballs.
- Installers ship the statically-linked musl binary, register with the host package manager so `apt remove pki-client` / `dnf remove pki-client` work cleanly.
- Each installer is signed with Sigstore cosign (keyless) and carries a SLSA provenance attestation from the GitHub Actions builder.

## Changes

- `crates/pki-client/Cargo.toml` — add `[package.metadata.deb]` + `[package.metadata.generate-rpm]` sections (license-file, extended description, doc-file packaging).
- `.github/workflows/release.yml` — rewritten to install `cargo-deb` + `cargo-generate-rpm`, produce `.deb` + `.rpm`, smoke-test with `dpkg-deb --info` / `rpm -qip`, attest + cosign-sign all installer artifacts.
- `install.sh` — detects host package format (`dpkg` vs `rpm`) and installs the matching installer via the native package manager.
- `README.md` — rewritten Install section showing apt/dnf install flow + per-installer cosign verification.
- `CHANGELOG.md` — add 0.9.1 entry.
- Workspace version 0.9.0 → 0.9.1. Packaging-only bump — binary is byte-identical to v0.9.0.

## Why

User directive: "We do not ship tar.gz files....we ship prebuilt installers." Native installers are the expected deployment shape on Linux. Users get integration with the distro's package manager, predictable install location, clean uninstall, and signed provenance per-installer.

## Test plan

- [x] `cargo check -p pki-client` — clean.
- [x] `python3 -c 'yaml.safe_load(...)'` on `.github/workflows/release.yml` — valid YAML.
- [x] `bash -n install.sh` — syntax OK.
- [x] Version bump propagates via `version.workspace = true` (verified with `cargo metadata`).
- [ ] Release workflow dry-run (fires on next `v0.9.1` tag push after merge).
- [ ] Published installers verified on a fresh Ubuntu + Rocky VM (post-tag).

Generated with Claude Code