### PR TITLE
fix(release): cargo-deb asset paths relative to crate manifest

### DIFF
--- a/crates/pki-client/Cargo.toml
+++ b/crates/pki-client/Cargo.toml
@@ -97,7 +97,7 @@ section = "utils"
 priority = "optional"
 depends = ""
 assets = [
-    ["target/x86_64-unknown-linux-musl/release/pki", "usr/bin/", "755"],
+    ["../../target/x86_64-unknown-linux-musl/release/pki", "usr/bin/", "755"],
     ["../../README.md", "usr/share/doc/pki-client/README.md", "644"],
     ["../../LICENSE", "usr/share/doc/pki-client/LICENSE", "644"],
 ]
@@ -107,7 +107,7 @@ name = "pki-client"
 summary = "Modern PKI CLI — cert inspection, key management, TLS probing"
 license = "Apache-2.0"
 assets = [
-    { source = "target/x86_64-unknown-linux-musl/release/pki", dest = "/usr/bin/pki", mode = "755" },
-    { source = "README.md", dest = "/usr/share/doc/pki-client/README.md", mode = "644", doc = true },
-    { source = "LICENSE", dest = "/usr/share/doc/pki-client/LICENSE", mode = "644", doc = true },
+    { source = "../../target/x86_64-unknown-linux-musl/release/pki", dest = "/usr/bin/pki", mode = "755" },
+    { source = "../../README.md", dest = "/usr/share/doc/pki-client/README.md", mode = "644", doc = true },
+    { source = "../../LICENSE", dest = "/usr/share/doc/pki-client/LICENSE", mode = "644", doc = true },
 ]


### PR DESCRIPTION
## Summary
- Fix release workflow failure: cargo-deb + cargo-generate-rpm resolve asset source paths relative to the crate manifest dir, not the workspace root
- Prefix asset sources in `[package.metadata.deb]` and `[package.metadata.generate-rpm]` with `../../` so they find the workspace-level `target/`, `README.md`, and `LICENSE`

## Context
v0.9.1 release workflow failed on the "Build .deb installer" step:
```
cargo-deb: Asset file path does not match any files:
  .../crates/pki-client/target/x86_64-unknown-linux-musl/release/pki
```
because cargo-deb resolved `target/x86_64-unknown-linux-musl/release/pki` relative to `crates/pki-client/` instead of the repo root where the workspace target dir actually lives.

## Test plan
- [x] TOML parses cleanly
- [ ] CI green on this PR
- [ ] After merge: re-tag v0.9.1 at the fix commit and verify release assets land

Generated with Claude Code