### PR TITLE
security: add workflow permissions for least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/crypto-validation.yml
+++ b/.github/workflows/crypto-validation.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/crypto-validation.yml
+++ b/.github/workflows/crypto-validation.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 6 * * 0'  # 06:00 UTC every Sunday
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 2 * * *'  # 02:30 UTC daily
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -13,6 +13,9 @@ on:
       - 'tests/interop/**'
       - '**/Cargo.toml'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 12 * * *'  # Noon UTC daily
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-check-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: release-check-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add explicit top-level \`permissions:\` blocks to 5 workflow files that were missing them
- Follows principle of least privilege — each workflow gets only the permissions it actually uses
- Resolves GitHub Code Security \"Workflow does not contain permissions\" alerts
- Two workflows (\`crypto-validation.yml\`, \`release-check.yml\`) that use \`gh issue create/close\` get \`issues: write\` in addition to \`contents: read\`

## Changes
- \`ci.yml\`: \`contents: read\` (build/test/audit only)
- \`daily-check.yml\`: \`contents: read\` (build/test/audit only)
- \`interop.yml\`: \`contents: read\` (build and artifact upload/download only)
- \`crypto-validation.yml\`: \`contents: read\` + \`issues: write\` (creates/closes GitHub issues on failure)
- \`release-check.yml\`: \`contents: read\` + \`issues: write\` (creates/closes GitHub issues on stale releases)

## Test plan
- [ ] CI passes on this PR
- [ ] No permission denied errors in workflow runs
- [ ] GitHub Code Security alerts resolve after merge

Generated with Claude Code