### PR TITLE
chore: /team review sweep — CI hardening, FIPS race fix, test coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Preflight: require the tagged commit to have a green CI run before anything
+  # else starts. This closes the gap that let the first v0.9.1 release attempt
+  # (run 24641035038) reach Sign-and-Release despite a failing commit.
+  verify-ci:
+    name: Verify CI passed on tagged commit
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 5
+    steps:
+      - name: Require latest CI run on this SHA to be success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "Checking CI status for $REPO @ $SHA"
+          # Take the most recent completed CI.yml run on the exact commit SHA.
+          status=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}&per_page=1" \
+            --jq '.workflow_runs[0] | {status: .status, conclusion: .conclusion, html_url: .html_url}')
+          echo "$status"
+          conclusion=$(echo "$status" | jq -r '.conclusion // "missing"')
+          if [[ "$conclusion" != "success" ]]; then
+            echo "::error::CI has not passed on ${SHA}: conclusion=${conclusion}. Aborting release."
+            exit 1
+          fi
+          echo "CI is green for this SHA."
+
   build-linux:
     name: Build Linux installers (.deb + .rpm)
+    needs: [verify-ci]
     # Pinned to ubuntu3-runner: musl-tools not available on Rocky Linux
     runs-on: [self-hosted, Linux]
     timeout-minutes: 45
@@ -101,7 +129,7 @@ jobs:
 
   sign-and-release:
     name: Sign and Release
-    needs: [build-linux]
+    needs: [verify-ci, build-linux]
     runs-on: [self-hosted, Linux]
     permissions:
       contents: write
@@ -132,10 +160,34 @@ jobs:
               exit 1
             fi
           fi
-      - name: Generate checksums
-        run: sha256sum pki-client_*.deb pki-client-*.rpm > SHA256SUMS.txt
+      # --- Supply chain security: Sigstore cosign signing ---
+      # Signing order matters for checksum coverage:
+      #   1. Sign .deb and .rpm first, producing .bundle files.
+      #   2. Generate SHA256SUMS.txt over every deliverable (installers + bundles).
+      #   3. Sign SHA256SUMS.txt itself, producing SHA256SUMS.txt.bundle.
+      # This way users who download SHA256SUMS.txt can sha256sum-verify every
+      # other asset; SHA256SUMS.txt.bundle is the Sigstore root of trust for it.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
+      - name: Sign installers with cosign (keyless)
+        run: |
+          set -euo pipefail
+          for f in pki-client_*.deb pki-client-*.rpm; do
+            cosign sign-blob --yes --bundle "${f}.bundle" "$f"
+          done
+      - name: Generate checksums (installers + bundles)
+        run: |
+          set -euo pipefail
+          sha256sum pki-client_*.deb pki-client-*.rpm \
+            pki-client_*.deb.bundle pki-client-*.rpm.bundle \
+            > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+      - name: Verify checksums round-trip
+        run: sha256sum -c SHA256SUMS.txt
+      - name: Sign SHA256SUMS.txt with cosign (keyless)
+        run: cosign sign-blob --yes --bundle SHA256SUMS.txt.bundle SHA256SUMS.txt
 
-      # --- Supply chain security: SLSA provenance ---
+      # --- Supply chain security: SLSA provenance (signed assets only) ---
       - name: Attest build provenance (.deb)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
@@ -148,15 +200,6 @@ jobs:
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
           subject-path: SHA256SUMS.txt
-
-      # --- Supply chain security: Sigstore cosign signing ---
-      - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
-      - name: Sign installers with cosign (keyless)
-        run: |
-          for f in pki-client_*.deb pki-client-*.rpm SHA256SUMS.txt; do
-            cosign sign-blob --yes --bundle "${f}.bundle" "$f"
-          done
 
       - name: Create GitHub Release
         env:

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ The TLS stack (`rustls` + `aws-lc-rs`) compiles native crypto from C source. You
 | CMake | aws-lc-sys | `sudo apt install cmake` |
 | Perl | aws-lc-sys build scripts | Usually pre-installed |
 
-Most users should use the [pre-built binary](#pre-built-binaries-recommended) instead of building from source.
+Most users should use the [pre-built binary](#install) instead of building from source.
 
 ### Build
 
@@ -421,7 +421,7 @@ To use enrollment protocols (ACME/EST/SCEP), pin to v0.8.1 or wait for the stand
 - **Static binaries** — musl builds eliminate shared-library supply-chain risk
 - **FIPS 140-3 mode** — restrict all operations to approved algorithms
 - **Input validation** — all file parsing uses safe, bounds-checked Rust decoders
-- **Dependency auditing** — `cargo audit` and `cargo deny` run in CI with zero-tolerance policy
+- **Dependency auditing** — `cargo audit` and `cargo deny` run in CI; every ignored advisory is documented in [`deny.toml`](deny.toml) with justification and review date
 - **Signed releases** — every binary is signed with [Sigstore cosign](https://www.sigstore.dev/) (keyless) and includes [SLSA provenance](https://slsa.dev/) attestations via GitHub Actions
 - **Vendored dependencies** — all crate dependencies are vendored and verified against `Cargo.lock` in CI; no git dependencies allowed
 

--- a/crates/pki-client/tests/cli_integration_tests.rs
+++ b/crates/pki-client/tests/cli_integration_tests.rs
@@ -1049,3 +1049,106 @@ fn issue_12_revoke_crl_show_missing_file_errors_cleanly() {
         "missing CRL file should exit non-zero"
     );
 }
+
+// ============================================================================
+// PQC Smoke Tests (ML-DSA-65) — feature-gated, skip when --features pqc absent
+// ============================================================================
+
+#[test]
+fn test_key_gen_mldsa65() {
+    if !binary_exists() {
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let key_path = temp_dir.path().join("mldsa65.key");
+
+    let output = Command::new(pki_binary())
+        .args(["key", "gen", "ml-dsa-65", "-o"])
+        .arg(&key_path)
+        .output()
+        .expect("Failed to execute pki");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("Unknown algorithm")
+            || stderr.contains("not supported")
+            || stderr.contains("not implemented")
+        {
+            eprintln!("Skipping: ML-DSA-65 unavailable (pqc feature disabled)");
+            return;
+        }
+        panic!("ml-dsa-65 keygen failed unexpectedly: {}", stderr);
+    }
+
+    assert!(key_path.exists(), "PQC key file not created");
+    let content = fs::read_to_string(&key_path).unwrap();
+    assert!(
+        content.contains("-----BEGIN PRIVATE KEY-----"),
+        "PQC key output missing PKCS#8 PEM header"
+    );
+}
+
+#[test]
+fn test_csr_create_mldsa65() {
+    if !binary_exists() {
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let key_path = temp_dir.path().join("mldsa65.key");
+    let csr_path = temp_dir.path().join("mldsa65.csr");
+
+    let keygen = Command::new(pki_binary())
+        .args(["key", "gen", "ml-dsa-65", "-o"])
+        .arg(&key_path)
+        .output()
+        .expect("Failed to execute pki keygen");
+
+    if !keygen.status.success() {
+        let stderr = String::from_utf8_lossy(&keygen.stderr);
+        if stderr.contains("Unknown algorithm")
+            || stderr.contains("not supported")
+            || stderr.contains("not implemented")
+        {
+            eprintln!("Skipping: ML-DSA-65 unavailable (pqc feature disabled)");
+            return;
+        }
+        panic!("ml-dsa-65 keygen failed unexpectedly: {}", stderr);
+    }
+
+    let output = Command::new(pki_binary())
+        .args([
+            "csr",
+            "create",
+            "--key",
+            key_path.to_str().unwrap(),
+            "--cn",
+            "pqc.example.com",
+            "-o",
+        ])
+        .arg(&csr_path)
+        .output()
+        .expect("Failed to execute pki csr create");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("not yet implemented")
+            || stderr.contains("not implemented")
+            || stderr.contains("not supported")
+            || stderr.contains("Failed to parse private key")
+            || stderr.contains("ECDSA P-256 PKCS#8 decode")
+        {
+            eprintln!("Skipping: pki csr create doesn't handle PQC keys yet (see #97)");
+            return;
+        }
+        panic!("PQC CSR creation failed: {}", stderr);
+    }
+
+    assert!(csr_path.exists(), "PQC CSR file not created");
+    let content = fs::read_to_string(&csr_path).unwrap();
+    assert!(
+        content.contains("-----BEGIN CERTIFICATE REQUEST-----"),
+        "PQC CSR missing PEM header"
+    );
+}

--- a/crates/pki-probe/tests/lint_tests.rs
+++ b/crates/pki-probe/tests/lint_tests.rs
@@ -275,3 +275,106 @@ fn issue_34_lint_does_not_flag_ca_cert_missing_san() {
         offending
     );
 }
+
+// ============================================================================
+// Lint positive-case tests — assert rules actually fire on violating certs
+// ============================================================================
+
+/// Leaf cert with validity > 398 days (triggers VALIDITY_TOO_LONG).
+fn generate_long_validity_leaf() -> Vec<u8> {
+    use spork_core::algo::{AlgorithmId, KeyPair};
+    use spork_core::cert::{
+        extensions::{BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsageFlags, SubjectAltName},
+        CertificateBuilder, NameBuilder, Validity,
+    };
+
+    let kp = KeyPair::generate(AlgorithmId::EcdsaP256).unwrap();
+    let subject = NameBuilder::new("longvalid.example.com")
+        .organization("Test Org")
+        .country("US")
+        .build();
+
+    let cert = CertificateBuilder::new(
+        subject,
+        kp.public_key_der().unwrap(),
+        AlgorithmId::EcdsaP256,
+    )
+    .validity(Validity::days_from_now(500))
+    .basic_constraints(BasicConstraints::end_entity())
+    .key_usage(KeyUsage::new(KeyUsageFlags::tls_server()))
+    .extended_key_usage(ExtendedKeyUsage::tls_server())
+    .subject_alt_name(SubjectAltName::new().dns("longvalid.example.com"))
+    .build_and_sign(&kp)
+    .unwrap();
+
+    use der::Encode;
+    cert.to_der().unwrap()
+}
+
+/// Leaf cert with no SAN extension (triggers MISSING_SAN).
+fn generate_leaf_without_san() -> Vec<u8> {
+    use spork_core::algo::{AlgorithmId, KeyPair};
+    use spork_core::cert::{
+        extensions::{BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsageFlags},
+        CertificateBuilder, NameBuilder, Validity,
+    };
+
+    let kp = KeyPair::generate(AlgorithmId::EcdsaP256).unwrap();
+    let subject = NameBuilder::new("nosan.example.com")
+        .organization("Test Org")
+        .country("US")
+        .build();
+
+    let cert = CertificateBuilder::new(
+        subject,
+        kp.public_key_der().unwrap(),
+        AlgorithmId::EcdsaP256,
+    )
+    .validity(Validity::days_from_now(90))
+    .basic_constraints(BasicConstraints::end_entity())
+    .key_usage(KeyUsage::new(KeyUsageFlags::tls_server()))
+    .extended_key_usage(ExtendedKeyUsage::tls_server())
+    .build_and_sign(&kp)
+    .unwrap();
+
+    use der::Encode;
+    cert.to_der().unwrap()
+}
+
+#[test]
+fn test_lint_validity_too_long_fires_on_500_day_leaf() {
+    let linter = CertLinter::new();
+    let cert = generate_long_validity_leaf();
+
+    let results = linter.lint_chain(&[cert]);
+
+    let hits: Vec<_> = results
+        .iter()
+        .filter(|r| r.rule_id == "VALIDITY_TOO_LONG")
+        .collect();
+
+    assert!(
+        !hits.is_empty(),
+        "500-day leaf should trigger VALIDITY_TOO_LONG, got rules: {:?}",
+        results.iter().map(|r| &r.rule_id).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_lint_missing_san_fires_on_leaf_without_san() {
+    let linter = CertLinter::new();
+    let cert = generate_leaf_without_san();
+
+    let results = linter.lint_chain(&[cert]);
+
+    let hits: Vec<_> = results
+        .iter()
+        .filter(|r| r.rule_id == "MISSING_SAN")
+        .collect();
+
+    assert!(
+        !hits.is_empty(),
+        "Leaf without SAN should trigger MISSING_SAN, got rules: {:?}",
+        results.iter().map(|r| &r.rule_id).collect::<Vec<_>>()
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,11 @@ ignore = [
     # pki-client does not install a custom global logger, so the unsound path is not reachable.
     # Drop this ignore once rand >= 0.9.3 is in our lockfile or we move to rand 0.10.
     { id = "RUSTSEC-2026-0097", reason = "rand 0.9.2 unsound path (custom logger) unreachable; awaiting rand 0.9.3+ (review by 2026-07-01)" },
+    # Review by 2026-09-01: sharks 0.5.0 Shamir polynomial bias.
+    # `sharks` is gated behind spork-core's `recovery` feature, which is NOT in its default feature set
+    # and is not enabled by any pki-client workspace crate. The code path is never compiled into the
+    # pki binary. Track migration to `vsss-rs` in spork-core before ever enabling `recovery`.
+    { id = "RUSTSEC-2024-0398", reason = "sharks is feature-gated (recovery), not compiled into pki binary (review by 2026-09-01)" },
 ]
 yanked = "warn"  # digest 0.11.1 yanked, transitive via spork-core PQC deps
 

--- a/vendor/spork-core/src/cert/verify.rs
+++ b/vendor/spork-core/src/cert/verify.rs
@@ -3221,6 +3221,9 @@ mod tests {
     #[test]
     #[cfg(all(feature = "pqc", not(feature = "fips")))] // ML-DSA not yet FIPS 140-3 validated
     fn test_valid_chain_mldsa65() {
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if crate::fips::is_fips_mode() {
             return;
         }
@@ -3511,6 +3514,12 @@ mod tests {
     fn test_pqc_cross_algorithm_chain() {
         // ML-DSA-65 root signs P-256 intermediate signs P-256 end-entity
         // Tests PQC→classical migration scenario
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if crate::fips::is_fips_mode() {
+            return;
+        }
         let (root_cert, mut root_ca) = create_root_ca("PQC-Cross Root", AlgorithmId::MlDsa65);
         let (_int_cert, mut int_ca) =
             create_intermediate_ca("PQC-Cross Int", AlgorithmId::EcdsaP256, &mut root_ca);
@@ -3531,6 +3540,9 @@ mod tests {
     #[test]
     #[cfg(all(feature = "pqc", not(feature = "fips")))] // ML-DSA not yet FIPS 140-3 validated
     fn test_valid_chain_mldsa44() {
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if crate::fips::is_fips_mode() {
             return;
         }
@@ -3550,6 +3562,9 @@ mod tests {
     #[test]
     #[cfg(all(feature = "pqc", not(feature = "fips")))] // ML-DSA not yet FIPS 140-3 validated
     fn test_valid_chain_mldsa87() {
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if crate::fips::is_fips_mode() {
             return;
         }

--- a/vendor/spork-core/src/fips.rs
+++ b/vendor/spork-core/src/fips.rs
@@ -485,12 +485,11 @@ pub fn keygen_preflight(algorithm: AlgorithmId) -> Result<()> {
 mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
-    #[cfg(not(feature = "fips"))]
     use std::sync::Mutex;
 
-    /// Mutex to serialize tests that toggle the global FIPS_MODE atomic.
-    /// Without this, parallel tests race on the shared flag.
-    #[cfg(not(feature = "fips"))]
+    /// Mutex to serialize tests that toggle shared atomics (FIPS_MODE,
+    /// SELF_TESTS_PASSED, ENTROPY_VALIDATED). Without this, parallel tests
+    /// race on the process-wide flags.
     static FIPS_LOCK: Mutex<()> = Mutex::new(());
 
     // Temporarily enable/disable FIPS mode for a test closure.

--- a/vendor/spork-core/src/fips.rs
+++ b/vendor/spork-core/src/fips.rs
@@ -500,7 +500,9 @@ mod tests {
     // Uses unwrap_or_else to recover from poisoned mutex (prior test panic).
     #[cfg(not(feature = "fips"))]
     fn with_fips_mode<F: FnOnce()>(f: F) {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(true, Ordering::SeqCst);
         f();
         FIPS_MODE.store(false, Ordering::SeqCst);
@@ -593,7 +595,9 @@ mod tests {
 
     #[test]
     fn test_non_fips_allows_everything() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         // Only run this test when the fips feature is not compiled in
         #[cfg(not(feature = "fips"))]
@@ -699,7 +703,9 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_enable_fips_mode_runtime() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         assert!(!is_fips_mode());
         enable_fips_mode();
@@ -740,7 +746,9 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_enable_fips_mode_with_self_tests() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         SELF_TESTS_PASSED.store(false, Ordering::SeqCst);
         ENTROPY_VALIDATED.store(false, Ordering::SeqCst);
@@ -762,14 +770,18 @@ mod tests {
 
     #[test]
     fn test_self_tests_passed_initially_false() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         SELF_TESTS_PASSED.store(false, Ordering::SeqCst);
         assert!(!self_tests_passed());
     }
 
     #[test]
     fn test_entropy_validated_initially_false() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         ENTROPY_VALIDATED.store(false, Ordering::SeqCst);
         assert!(!entropy_validated());
     }
@@ -910,7 +922,9 @@ mod tests {
         use crate::algo::KeyPair;
         // Hold FIPS lock to prevent race with tests that temporarily enable FIPS mode,
         // which would cause KeyPair::generate(Ed25519) to be rejected.
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         let key = KeyPair::generate(AlgorithmId::Ed25519).unwrap();
         let result = pairwise_consistency_test(&key);
@@ -925,7 +939,9 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_keygen_preflight_non_fips_allows_all() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         // Non-FIPS mode should allow everything
         assert!(keygen_preflight(AlgorithmId::EcdsaP256).is_ok());
@@ -1045,7 +1061,9 @@ mod tests {
     #[cfg(not(feature = "fips"))] // Ed25519 rejected by FIPS algorithm validation
     fn test_key_import_self_test_ed25519() {
         // Guard against runtime FIPS mode set by parallel tests
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         let key = crate::algo::KeyPair::generate(AlgorithmId::Ed25519)
             .expect("Ed25519 keygen should work");
@@ -1068,7 +1086,9 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_fips_module_activated_after_self_tests() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Reset state
         FIPS_MODULE_STATE.store(FipsModuleState::PowerOff as u8, Ordering::SeqCst);
         FIPS_MODE.store(false, Ordering::SeqCst);
@@ -1092,7 +1112,9 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_fips_module_deactivation() {
-        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Activate first
         FIPS_MODE.store(true, Ordering::SeqCst);
         FIPS_MODULE_STATE.store(FipsModuleState::Activated as u8, Ordering::SeqCst);

--- a/vendor/spork-core/src/fips.rs
+++ b/vendor/spork-core/src/fips.rs
@@ -591,6 +591,7 @@ mod tests {
 
     #[test]
     fn test_non_fips_allows_everything() {
+        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         // Only run this test when the fips feature is not compiled in
         #[cfg(not(feature = "fips"))]
@@ -759,13 +760,14 @@ mod tests {
 
     #[test]
     fn test_self_tests_passed_initially_false() {
-        // Reset state
+        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         SELF_TESTS_PASSED.store(false, Ordering::SeqCst);
         assert!(!self_tests_passed());
     }
 
     #[test]
     fn test_entropy_validated_initially_false() {
+        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         ENTROPY_VALIDATED.store(false, Ordering::SeqCst);
         assert!(!entropy_validated());
     }
@@ -921,6 +923,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_keygen_preflight_non_fips_allows_all() {
+        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         // Non-FIPS mode should allow everything
         assert!(keygen_preflight(AlgorithmId::EcdsaP256).is_ok());

--- a/vendor/spork-core/src/fips.rs
+++ b/vendor/spork-core/src/fips.rs
@@ -43,6 +43,15 @@ pub enum FipsModuleState {
 /// Global FIPS mode flag (runtime).
 static FIPS_MODE: AtomicBool = AtomicBool::new(false);
 
+/// Crate-wide serialization lock for tests that observe or toggle process-wide
+/// FIPS atomics (FIPS_MODE, SELF_TESTS_PASSED, ENTROPY_VALIDATED). Any test in
+/// any module that depends on FIPS_MODE staying stable during execution MUST
+/// acquire this lock — otherwise a parallel test in `fips::tests` can flip
+/// FIPS_MODE mid-run and cause spurious failures (e.g. ML-DSA rejected under
+/// FIPS, producing malformed DER downstream).
+#[cfg(test)]
+pub(crate) static TEST_FIPS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Tracks whether power-up self-tests have been run and passed.
 static SELF_TESTS_PASSED: AtomicBool = AtomicBool::new(false);
 
@@ -485,19 +494,13 @@ pub fn keygen_preflight(algorithm: AlgorithmId) -> Result<()> {
 mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
-    use std::sync::Mutex;
-
-    /// Mutex to serialize tests that toggle shared atomics (FIPS_MODE,
-    /// SELF_TESTS_PASSED, ENTROPY_VALIDATED). Without this, parallel tests
-    /// race on the process-wide flags.
-    static FIPS_LOCK: Mutex<()> = Mutex::new(());
 
     // Temporarily enable/disable FIPS mode for a test closure.
     // Only valid in non-fips-feature builds (feature flag makes it permanent).
     // Uses unwrap_or_else to recover from poisoned mutex (prior test panic).
     #[cfg(not(feature = "fips"))]
     fn with_fips_mode<F: FnOnce()>(f: F) {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(true, Ordering::SeqCst);
         f();
         FIPS_MODE.store(false, Ordering::SeqCst);
@@ -590,7 +593,7 @@ mod tests {
 
     #[test]
     fn test_non_fips_allows_everything() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         // Only run this test when the fips feature is not compiled in
         #[cfg(not(feature = "fips"))]
@@ -696,7 +699,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_enable_fips_mode_runtime() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         assert!(!is_fips_mode());
         enable_fips_mode();
@@ -737,7 +740,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_enable_fips_mode_with_self_tests() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         SELF_TESTS_PASSED.store(false, Ordering::SeqCst);
         ENTROPY_VALIDATED.store(false, Ordering::SeqCst);
@@ -759,14 +762,14 @@ mod tests {
 
     #[test]
     fn test_self_tests_passed_initially_false() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         SELF_TESTS_PASSED.store(false, Ordering::SeqCst);
         assert!(!self_tests_passed());
     }
 
     #[test]
     fn test_entropy_validated_initially_false() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         ENTROPY_VALIDATED.store(false, Ordering::SeqCst);
         assert!(!entropy_validated());
     }
@@ -907,7 +910,7 @@ mod tests {
         use crate::algo::KeyPair;
         // Hold FIPS lock to prevent race with tests that temporarily enable FIPS mode,
         // which would cause KeyPair::generate(Ed25519) to be rejected.
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         let key = KeyPair::generate(AlgorithmId::Ed25519).unwrap();
         let result = pairwise_consistency_test(&key);
@@ -922,7 +925,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_keygen_preflight_non_fips_allows_all() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         // Non-FIPS mode should allow everything
         assert!(keygen_preflight(AlgorithmId::EcdsaP256).is_ok());
@@ -1042,7 +1045,7 @@ mod tests {
     #[cfg(not(feature = "fips"))] // Ed25519 rejected by FIPS algorithm validation
     fn test_key_import_self_test_ed25519() {
         // Guard against runtime FIPS mode set by parallel tests
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         FIPS_MODE.store(false, Ordering::SeqCst);
         let key = crate::algo::KeyPair::generate(AlgorithmId::Ed25519)
             .expect("Ed25519 keygen should work");
@@ -1065,7 +1068,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_fips_module_activated_after_self_tests() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Reset state
         FIPS_MODULE_STATE.store(FipsModuleState::PowerOff as u8, Ordering::SeqCst);
         FIPS_MODE.store(false, Ordering::SeqCst);
@@ -1089,7 +1092,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_fips_module_deactivation() {
-        let _guard = FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::fips::TEST_FIPS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Activate first
         FIPS_MODE.store(true, Ordering::SeqCst);
         FIPS_MODULE_STATE.store(FipsModuleState::Activated as u8, Ordering::SeqCst);


### PR DESCRIPTION
## Summary
Bundles the fixes from the /team multi-agent review (architect + secops + tester + devops + verifier) into one reviewable PR. Four logical commits:

- **security: FIPS_MODE test mutex (#94)** — parallel tests flipped the process-wide atomic; FIPS_LOCK serializes the race-prone cases. 48/48 FIPS tests green under the fix.
- **ci: harden release pipeline** — verify-ci preflight gates on a green CI run for the tagged SHA (closes the window the first v0.9.1 attempt slipped through). SHA256SUMS.txt now covers .deb, .rpm, and every .bundle, with a round-trip sha256sum -c step before signing. deny.toml ignores RUSTSEC-2024-0398 (sharks, feature-gated behind an unused feature).
- **docs: README** — fixes #pre-built-binaries-recommended anchor and softens overclaimed wording.
- **test: coverage additions** — ML-DSA-65 keygen smoke + CSR canary (skips on #97 until fixed), plus positive-case lint tests for VALIDITY_TOO_LONG and MISSING_SAN.

## Test plan
- [x] cargo fmt --all (clean)
- [x] cargo clippy --all-targets --features pqc -- -D warnings (clean)
- [x] ML-DSA-65 keygen + CSR canary tests pass (CSR currently skips with #97 reference)
- [x] FIPS suite 48/48 under FIPS_LOCK
- [ ] CI green on self-hosted runners

Generated with Claude Code