### PR TITLE
v0.9.3 hardening: parser bug fix + CI gate hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,11 @@ jobs:
     needs: [fmt, clippy-fips]
     runs-on: [self-hosted, Linux]
     timeout-minutes: 20
-    continue-on-error: true  # FIPS entropy health check can be non-deterministic
+    # NB: job-level continue-on-error was removed (DevOps P1 hardening) —
+    # it silenced compile errors and real test regressions, not just the
+    # flaky entropy check. Compile must always be a hard gate; only the
+    # test-execution step is allowed to soft-fail until the entropy
+    # health-check is deflaked.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -220,7 +224,10 @@ jobs:
         with:
           cache-prefix: v3-test-fips
 
-      - name: cargo test --features fips
+      - name: cargo build --tests --features fips (hard gate)
+        run: cargo build --all --tests --features fips
+      - name: cargo test --features fips (soft gate, flaky entropy check)
+        continue-on-error: true
         run: cargo test --all --features fips
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,18 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}&per_page=1")
-          echo "$response" | jq '.workflow_runs[0] | {status, conclusion, html_url}'
+          echo "$response" | jq '.workflow_runs[0] | {head_sha, status, conclusion, html_url}'
+          # Belt-and-braces: pin the picked run to the exact tagged SHA.
+          # The head_sha query param is a filter, but defending against a
+          # future API edge case (or a forced-push race) costs one jq
+          # filter and stops a green-on-different-sha run from being
+          # accepted as proof. (DevOps P1 hardening.)
+          run_sha=$(echo "$response" | jq -r '.workflow_runs[0].head_sha // "missing"')
           conclusion=$(echo "$response" | jq -r '.workflow_runs[0].conclusion // "missing"')
+          if [[ "$run_sha" != "$SHA" ]]; then
+            echo "::error::No CI run found for ${SHA} (got head_sha=${run_sha}). Aborting release."
+            exit 1
+          fi
           if [[ "$conclusion" != "success" ]]; then
             echo "::error::CI has not passed on ${SHA}: conclusion=${conclusion}. Aborting release."
             exit 1

--- a/crates/pki-client/src/compat.rs
+++ b/crates/pki-client/src/compat.rs
@@ -2067,7 +2067,28 @@ impl GeneratedKey {
 
 /// Load private key from file
 pub fn load_private_key(path: &Path) -> Result<PrivateKey> {
-    let data = std::fs::read_to_string(path)?;
+    let data = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read key file: {}", path.display()))?;
+
+    // Reject empty / whitespace-only inputs before any heuristic fires.
+    // Without this, the RSA-2048 default at the bottom of this function
+    // would happily report "" as a valid 2048-bit RSA key (issue #102).
+    if data.trim().is_empty() {
+        anyhow::bail!(
+            "{}: file is empty or contains no key material",
+            path.display()
+        );
+    }
+
+    // Validate that the input is actually a recognisable PEM block.
+    // pem::parse rejects: missing BEGIN/END frames, mismatched labels,
+    // non-base64 bodies, and empty bodies. Bailing here closes the
+    // garbage-in / RSA-2048-out path the size heuristics fell through to.
+    let parsed_pem = pem::parse(&data)
+        .with_context(|| format!("{}: not a valid PEM-encoded private key", path.display()))?;
+    if parsed_pem.contents().is_empty() {
+        anyhow::bail!("{}: PEM frame contained no key material", path.display());
+    }
 
     // Check if encrypted
     let encrypted = data.contains("ENCRYPTED");

--- a/crates/pki-client/tests/key_show_algorithms.rs
+++ b/crates/pki-client/tests/key_show_algorithms.rs
@@ -94,34 +94,38 @@ fn key_show_detects_rsa() {
     assert_algo("rsa", &["\"Rsa\"", "4096"]);
 }
 
+// ML-DSA assertions include the parameter-set integer so a regression that
+// collapses 44/65/87 onto a single value is caught (Tester P1 finding).
 #[test]
 fn key_show_detects_mldsa44() {
-    assert_algo("ml-dsa-44", &["MlDsa"]);
+    assert_algo("ml-dsa-44", &["\"MlDsa\": 44"]);
 }
 
 #[test]
 fn key_show_detects_mldsa65() {
-    assert_algo("ml-dsa-65", &["MlDsa"]);
+    assert_algo("ml-dsa-65", &["\"MlDsa\": 65"]);
 }
 
 #[test]
 fn key_show_detects_mldsa87() {
-    assert_algo("ml-dsa-87", &["MlDsa"]);
+    assert_algo("ml-dsa-87", &["\"MlDsa\": 87"]);
 }
 
+// SLH-DSA assertions pin the hash family + parameter set so a swap to a
+// neighbouring variant (e.g., 128s misreported as 192s) is caught.
 #[test]
 fn key_show_detects_slhdsa_128s() {
-    assert_algo("slh-dsa-128s", &["SlhDsa"]);
+    assert_algo("slh-dsa-128s", &["\"SlhDsa\": \"SHA2-128s\""]);
 }
 
 #[test]
 fn key_show_detects_slhdsa_192s() {
-    assert_algo("slh-dsa-192s", &["SlhDsa"]);
+    assert_algo("slh-dsa-192s", &["\"SlhDsa\": \"SHA2-192s\""]);
 }
 
 #[test]
 fn key_show_detects_slhdsa_256s() {
-    assert_algo("slh-dsa-256s", &["SlhDsa"]);
+    assert_algo("slh-dsa-256s", &["\"SlhDsa\": \"SHA2-256s\""]);
 }
 
 // Future-guard: when `pki key gen ed25519` is re-enabled, detection must

--- a/crates/pki-client/tests/malformed_input.rs
+++ b/crates/pki-client/tests/malformed_input.rs
@@ -1,0 +1,180 @@
+//! Adversarial input tests for `pki cert show`, `pki key show`, `pki csr show`.
+//!
+//! Tester P1 finding: the existing CLI integration tests cover well-formed
+//! inputs and the "file does not exist" path, but never fed malformed bytes
+//! to the parsers. A regression where x509-parser panics on truncated DER or
+//! the PEM decoder loops on corrupt base64 would slip through CI.
+//!
+//! Each test asserts: the process exits non-zero, stays under a watchdog
+//! deadline (no hangs), and does not panic (no `thread 'main' panicked`).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+
+fn pki_binary() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path.push("target");
+    path.push("debug");
+    path.push("pki");
+    path
+}
+
+fn binary_exists() -> bool {
+    pki_binary().exists()
+}
+
+fn write_fixture(bytes: &[u8]) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("tmp");
+    f.write_all(bytes).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn assert_rejects(subcommand: &[&str], input: &[u8], label: &str) {
+    if !binary_exists() {
+        return;
+    }
+    let f = write_fixture(input);
+    let out = Command::new(pki_binary())
+        .args(subcommand)
+        .arg(f.path())
+        .output()
+        .expect("spawn pki");
+
+    assert!(
+        !out.status.success(),
+        "[{label}] {subcommand:?} should reject malformed input but exited 0:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "[{label}] {subcommand:?} panicked on malformed input:\n{stderr}",
+    );
+    assert!(
+        !stderr.contains("RUST_BACKTRACE"),
+        "[{label}] {subcommand:?} produced a backtrace (likely panic):\n{stderr}",
+    );
+}
+
+// --- Fixtures -----------------------------------------------------------
+
+const EMPTY: &[u8] = b"";
+const GARBAGE: &[u8] = b"this is not a certificate or a key, just bytes\n";
+
+// PEM frame with a recognised label but invalid base64 body.
+const CORRUPT_PEM_CERT: &[u8] =
+    b"-----BEGIN CERTIFICATE-----\n!!!not-base64!!!\n-----END CERTIFICATE-----\n";
+const CORRUPT_PEM_KEY: &[u8] =
+    b"-----BEGIN PRIVATE KEY-----\n!!!not-base64!!!\n-----END PRIVATE KEY-----\n";
+const CORRUPT_PEM_CSR: &[u8] =
+    b"-----BEGIN CERTIFICATE REQUEST-----\n!!!\n-----END CERTIFICATE REQUEST-----\n";
+
+// Valid PEM frame with an empty (zero-length) body.
+const EMPTY_PEM_CERT: &[u8] = b"-----BEGIN CERTIFICATE-----\n\n-----END CERTIFICATE-----\n";
+
+// Truncated DER: SEQUENCE tag claiming 0x82 (long-form, 2 length bytes) but
+// no body. Common shape for cut-off downloads.
+const TRUNCATED_DER: &[u8] = &[0x30, 0x82, 0x01, 0x00];
+
+// --- pki cert show ------------------------------------------------------
+
+#[test]
+fn cert_show_rejects_empty_file() {
+    assert_rejects(&["cert", "show"], EMPTY, "cert empty");
+}
+
+#[test]
+fn cert_show_rejects_garbage() {
+    assert_rejects(&["cert", "show"], GARBAGE, "cert garbage");
+}
+
+#[test]
+fn cert_show_rejects_corrupt_pem() {
+    assert_rejects(&["cert", "show"], CORRUPT_PEM_CERT, "cert corrupt-pem");
+}
+
+#[test]
+fn cert_show_rejects_empty_pem_body() {
+    assert_rejects(&["cert", "show"], EMPTY_PEM_CERT, "cert empty-pem-body");
+}
+
+#[test]
+fn cert_show_rejects_truncated_der() {
+    assert_rejects(&["cert", "show"], TRUNCATED_DER, "cert truncated-der");
+}
+
+// --- pki key show -------------------------------------------------------
+
+#[test]
+fn key_show_rejects_empty_file() {
+    assert_rejects(&["key", "show"], EMPTY, "key empty");
+}
+
+#[test]
+fn key_show_rejects_garbage() {
+    assert_rejects(&["key", "show"], GARBAGE, "key garbage");
+}
+
+#[test]
+fn key_show_rejects_corrupt_pem() {
+    assert_rejects(&["key", "show"], CORRUPT_PEM_KEY, "key corrupt-pem");
+}
+
+#[test]
+fn key_show_rejects_truncated_der() {
+    assert_rejects(&["key", "show"], TRUNCATED_DER, "key truncated-der");
+}
+
+// --- pki csr show -------------------------------------------------------
+
+#[test]
+fn csr_show_rejects_empty_file() {
+    assert_rejects(&["csr", "show"], EMPTY, "csr empty");
+}
+
+#[test]
+fn csr_show_rejects_garbage() {
+    assert_rejects(&["csr", "show"], GARBAGE, "csr garbage");
+}
+
+#[test]
+fn csr_show_rejects_corrupt_pem() {
+    assert_rejects(&["csr", "show"], CORRUPT_PEM_CSR, "csr corrupt-pem");
+}
+
+// --- Watchdog: cert show must exit within 10 s on any input -----------
+
+#[test]
+fn cert_show_does_not_hang_on_garbage() {
+    if !binary_exists() {
+        return;
+    }
+    let f = write_fixture(GARBAGE);
+    let mut child = Command::new(pki_binary())
+        .args(["cert", "show"])
+        .arg(f.path())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                panic!("pki cert show hung on garbage input (>10s)");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}

--- a/tools/gen-signing-certs/src/main.rs
+++ b/tools/gen-signing-certs/src/main.rs
@@ -5,6 +5,8 @@
 //!
 //! Output: /tmp/pki-sign/certs/{type}_{algo}.pfx
 
+#![forbid(unsafe_code)]
+
 use std::path::Path;
 
 use const_oid::ObjectIdentifier;


### PR DESCRIPTION
## Summary

Three changes from the /team review of post-v0.9.2 state:

- **fix:** `pki key show` was reporting empty / garbage / corrupt-PEM input as valid RSA-2048 keys. The parser fell through to a silent default when no PEM markers matched. Now requires a parseable PEM block with non-empty body before any heuristic fires. Closes a Tester P1 finding.
- **security:** add `#\![forbid(unsafe_code)]` to `tools/gen-signing-certs/src/main.rs` so the test-cert generator matches the project-wide deny every other crate enforces. SecOps P1 finding.
- **ci:** harden `release.yml` verify-ci gate to assert the picked workflow run's `head_sha` equals the tagged SHA; split `test-fips` job into a hard build gate + soft test gate so compile errors are no longer silenced by the flaky-entropy escape hatch. DevOps P1 findings.

## Test plan

- [x] `cargo test --features pqc -p pki-client` — 297/297 pass (incl. 13 new adversarial-input tests + strengthened ML-DSA / SLH-DSA assertions)
- [x] `cargo clippy --all-targets --features pqc -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] Full CI run on this branch

If green, will tag v0.9.3 and redeploy to Rocky 9.7 interop runner.

Generated with Claude Code