### PR TITLE
chore(release): single static musl binary instead of .deb + .rpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,10 @@ jobs:
           echo "CI is green for this SHA."
 
   build-linux:
-    name: Build Linux installers (.deb + .rpm)
+    name: Build static musl binary
     needs: [verify-ci]
-    # Pinned to ubuntu3-runner: musl-tools not available on Rocky Linux
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -73,14 +72,6 @@ jobs:
           if ! command -v musl-gcc &> /dev/null; then
             sudo apt-get update
             sudo apt-get install -y musl-tools
-          fi
-      - name: Install cargo-deb and cargo-generate-rpm
-        run: |
-          if ! command -v cargo-deb &> /dev/null; then
-            cargo install --locked cargo-deb@2.7.0
-          fi
-          if ! command -v cargo-generate-rpm &> /dev/null; then
-            cargo install --locked cargo-generate-rpm@0.14.1
           fi
       - name: Build static binary (with PQC support)
         run: cargo build --release --features pqc --target x86_64-unknown-linux-musl -p pki-client
@@ -98,50 +89,23 @@ jobs:
           fi
           ls -lh target/x86_64-unknown-linux-musl/release/pki
 
-      # ── Build .deb installer ──────────────────────────────────────
-      - name: Build .deb installer
+      - name: Stage release artifact
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           VERSION="${TAG_NAME#v}"
-          cargo deb --no-build --no-strip \
-            --target x86_64-unknown-linux-musl \
-            -p pki-client \
-            --output "pki-client_${VERSION}_amd64.deb"
-          ls -lh pki-client_*.deb
-
-      # ── Build .rpm installer ──────────────────────────────────────
-      - name: Build .rpm installer
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          VERSION="${TAG_NAME#v}"
-          cargo generate-rpm \
-            --target x86_64-unknown-linux-musl \
-            -p crates/pki-client \
-            --output "pki-client-${VERSION}-1.x86_64.rpm"
-          ls -lh pki-client-*.rpm
-
-      # ── Smoke-test installers ─────────────────────────────────────
-      - name: Smoke-test .deb (dpkg-deb inspection)
-        run: |
-          dpkg-deb --info pki-client_*.deb
-          dpkg-deb --contents pki-client_*.deb
-      - name: Smoke-test .rpm (rpm inspection)
-        run: |
-          if command -v rpm &> /dev/null; then
-            rpm -qip pki-client-*.rpm
-            rpm -qlp pki-client-*.rpm
-          else
-            echo "rpm not installed on runner — skipping inspection"
-          fi
+          ASSET="pki-${VERSION}-linux-x86_64-musl"
+          cp target/x86_64-unknown-linux-musl/release/pki "$ASSET"
+          chmod +x "$ASSET"
+          ls -lh "$ASSET"
+          # Smoke-test: the binary itself runs and reports the right version.
+          ./"$ASSET" --version
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
-          name: pki-linux-installers
-          path: |
-            pki-client_*.deb
-            pki-client-*.rpm
+          name: pki-linux-musl
+          path: pki-*-linux-x86_64-musl
 
   sign-and-release:
     name: Sign and Release
@@ -176,27 +140,26 @@ jobs:
               exit 1
             fi
           fi
+
       # --- Supply chain security: Sigstore cosign signing ---
       # Signing order matters for checksum coverage:
-      #   1. Sign .deb and .rpm first, producing .bundle files.
-      #   2. Generate SHA256SUMS.txt over every deliverable (installers + bundles).
+      #   1. Sign the binary first, producing a .bundle file.
+      #   2. Generate SHA256SUMS.txt over both deliverables (binary + bundle).
       #   3. Sign SHA256SUMS.txt itself, producing SHA256SUMS.txt.bundle.
-      # This way users who download SHA256SUMS.txt can sha256sum-verify every
-      # other asset; SHA256SUMS.txt.bundle is the Sigstore root of trust for it.
+      # Users who download SHA256SUMS.txt can sha256sum-verify the binary;
+      # SHA256SUMS.txt.bundle is the Sigstore root of trust for the file.
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
-      - name: Sign installers with cosign (keyless)
+      - name: Sign binary with cosign (keyless)
         run: |
           set -euo pipefail
-          for f in pki-client_*.deb pki-client-*.rpm; do
+          for f in pki-*-linux-x86_64-musl; do
             cosign sign-blob --yes --bundle "${f}.bundle" "$f"
           done
-      - name: Generate checksums (installers + bundles)
+      - name: Generate checksums (binary + bundle)
         run: |
           set -euo pipefail
-          sha256sum pki-client_*.deb pki-client-*.rpm \
-            pki-client_*.deb.bundle pki-client-*.rpm.bundle \
-            > SHA256SUMS.txt
+          sha256sum pki-*-linux-x86_64-musl pki-*-linux-x86_64-musl.bundle > SHA256SUMS.txt
           cat SHA256SUMS.txt
       - name: Verify checksums round-trip
         run: sha256sum -c SHA256SUMS.txt
@@ -204,14 +167,10 @@ jobs:
         run: cosign sign-blob --yes --bundle SHA256SUMS.txt.bundle SHA256SUMS.txt
 
       # --- Supply chain security: SLSA provenance (signed assets only) ---
-      - name: Attest build provenance (.deb)
+      - name: Attest build provenance (binary)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
-          subject-path: pki-client_*.deb
-      - name: Attest build provenance (.rpm)
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
-        with:
-          subject-path: pki-client-*.rpm
+          subject-path: pki-*-linux-x86_64-musl
       - name: Attest build provenance (checksums)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
@@ -225,4 +184,4 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --generate-notes \
-            pki-client_*.deb pki-client-*.rpm SHA256SUMS.txt *.bundle
+            pki-*-linux-x86_64-musl SHA256SUMS.txt *.bundle

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Pure Rust. No OpenSSL dependency. Human-friendly output. One static binary (musl
 [![OpenSSL](https://img.shields.io/badge/OpenSSL-not%20required-brightgreen?logo=openssl&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client)
 
 <!-- Project Info -->
-[![Version](https://img.shields.io/badge/version-0.9.2-blue?logo=semver&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client/releases)
+[![Version](https://img.shields.io/badge/version-0.9.3-blue?logo=semver&logoColor=white)](https://github.com/rayketcham-lab/PKI-Client/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green?logo=apache&logoColor=white)](LICENSE)
 [![Rust](https://img.shields.io/badge/language-Rust-orange?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![MSRV](https://img.shields.io/badge/MSRV-1.88.0-orange?logo=rust&logoColor=white)](https://blog.rust-lang.org/)
@@ -235,57 +235,44 @@ Certificate:
 
 ## Install
 
-`pki-client` ships as native Linux installers — `.deb` for Debian/Ubuntu and `.rpm` for RHEL/Fedora/Rocky/Alma. The binary is statically linked against musl libc — zero runtime dependencies. Installers deploy `pki` to `/usr/bin/pki` with appropriate permissions and register with the distro's package manager so `apt remove` / `dnf remove` work as expected.
+`pki-client` ships as a single statically-linked musl binary — zero runtime dependencies, runs on any x86_64 Linux distro (Debian, Ubuntu, RHEL, Rocky, Alma, Fedora, Alpine, etc.).
 
-### Debian / Ubuntu (.deb)
+### One-line install
 
 ```bash
-# Download installer + signatures
-VERSION=v0.9.2
-curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client_${VERSION#v}_amd64.deb
-curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client_${VERSION#v}_amd64.deb.bundle
+curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash
+```
+
+The installer downloads the binary, verifies its SHA256, and drops it at `/usr/local/bin/pki` (override with `PKI_INSTALL_PATH=/some/other/path`).
+
+**Upgrade:** `curl -fsSL .../install.sh | sudo bash -s -- upgrade`
+**Uninstall:** `curl -fsSL .../install.sh | sudo bash -s -- uninstall`
+**Pin version:** `curl -fsSL .../install.sh | sudo bash -s -- v0.9.3`
+
+### Manual install
+
+```bash
+VERSION=v0.9.3
+ASSET=pki-${VERSION#v}-linux-x86_64-musl
+
+# Download binary + signature bundle
+curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/${ASSET}
+curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/${ASSET}.bundle
 
 # (optional) Verify signature — see "Verify release integrity" below
 cosign verify-blob \
-  --bundle pki-client_${VERSION#v}_amd64.deb.bundle \
+  --bundle ${ASSET}.bundle \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
-  pki-client_${VERSION#v}_amd64.deb
+  ${ASSET}
 
 # Install
-sudo dpkg -i pki-client_${VERSION#v}_amd64.deb
+chmod +x ${ASSET}
+sudo mv ${ASSET} /usr/local/bin/pki
 
 # Verify
 pki --version
 ```
-
-**Upgrade / reinstall:** `sudo dpkg -i pki-client_*.deb` (overwrites in place)
-**Uninstall:** `sudo apt remove pki-client`
-
-### RHEL / Fedora / Rocky / Alma (.rpm)
-
-```bash
-# Download installer + signatures
-VERSION=v0.9.2
-curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client-${VERSION#v}-1.x86_64.rpm
-curl -fSLO https://github.com/rayketcham-lab/PKI-Client/releases/download/${VERSION}/pki-client-${VERSION#v}-1.x86_64.rpm.bundle
-
-# (optional) Verify signature — see "Verify release integrity" below
-cosign verify-blob \
-  --bundle pki-client-${VERSION#v}-1.x86_64.rpm.bundle \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
-  pki-client-${VERSION#v}-1.x86_64.rpm
-
-# Install (dnf/yum auto-resolves no deps — binary is static)
-sudo dnf install -y ./pki-client-${VERSION#v}-1.x86_64.rpm
-
-# Verify
-pki --version
-```
-
-**Upgrade:** `sudo dnf upgrade ./pki-client-*.rpm`
-**Uninstall:** `sudo dnf remove pki-client`
 
 **Platform:** x86_64 Linux. The binary is statically linked (musl) — zero runtime dependencies, installs cleanly on any glibc or musl host.
 
@@ -293,7 +280,7 @@ Browse all assets at [GitHub Releases](https://github.com/rayketcham-lab/PKI-Cli
 
 ### Verify release integrity
 
-Every release ships with SHA256 checksums, [SLSA build provenance](https://slsa.dev/), and [Sigstore](https://www.sigstore.dev/) cosign signatures. All installers are built by GitHub Actions directly from tagged source — no human touches the binary.
+Every release ships with SHA256 checksums, [SLSA build provenance](https://slsa.dev/), and [Sigstore](https://www.sigstore.dev/) cosign signatures. The binary is built by GitHub Actions directly from tagged source — no human touches it.
 
 **SHA256 checksum:**
 ```bash
@@ -303,18 +290,16 @@ sha256sum -c --ignore-missing SHA256SUMS.txt
 
 **GitHub attestation (SLSA provenance):**
 ```bash
-gh attestation verify pki-client_0.9.2_amd64.deb --repo rayketcham-lab/PKI-Client
-gh attestation verify pki-client-0.9.2-1.x86_64.rpm --repo rayketcham-lab/PKI-Client
+gh attestation verify pki-0.9.3-linux-x86_64-musl --repo rayketcham-lab/PKI-Client
 ```
 
 **Cosign signature (Sigstore keyless):**
 ```bash
-# .deb example (see per-distro sections above for inline usage)
 cosign verify-blob \
-  --bundle pki-client_0.9.2_amd64.deb.bundle \
+  --bundle pki-0.9.3-linux-x86_64-musl.bundle \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp "github.com/rayketcham-lab/PKI-Client" \
-  pki-client_0.9.2_amd64.deb
+  pki-0.9.3-linux-x86_64-musl
 ```
 
 ### Shell completions

--- a/crates/pki-client/Cargo.toml
+++ b/crates/pki-client/Cargo.toml
@@ -77,37 +77,3 @@ tempfile = { workspace = true }
 const-oid = "0.9"
 der = { workspace = true }
 
-# ── Linux package metadata ──────────────────────────────────────────
-# Both packages ship the statically-linked musl binary — zero runtime deps.
-# Build with: cargo build --release --features pqc --target x86_64-unknown-linux-musl
-# Package with:
-#   cargo deb --no-build --target x86_64-unknown-linux-musl -p pki-client
-#   cargo generate-rpm --target x86_64-unknown-linux-musl -p crates/pki-client
-
-[package.metadata.deb]
-name = "pki-client"
-maintainer = "Ray Ketcham <rayketcham@ogjos.com>"
-copyright = "2026, Ray Ketcham <rayketcham@ogjos.com>"
-license-file = ["../../LICENSE", "0"]
-extended-description = """\
-Modern PKI CLI tool — certificate inspection, key management, TLS probing, \
-compliance validation, DANE, and chain building. Pure Rust, no OpenSSL \
-dependency. Statically linked with musl — zero runtime dependencies."""
-section = "utils"
-priority = "optional"
-depends = ""
-assets = [
-    ["../../target/x86_64-unknown-linux-musl/release/pki", "usr/bin/", "755"],
-    ["../../README.md", "usr/share/doc/pki-client/README.md", "644"],
-    ["../../LICENSE", "usr/share/doc/pki-client/LICENSE", "644"],
-]
-
-[package.metadata.generate-rpm]
-name = "pki-client"
-summary = "Modern PKI CLI — cert inspection, key management, TLS probing"
-license = "Apache-2.0"
-assets = [
-    { source = "../../target/x86_64-unknown-linux-musl/release/pki", dest = "/usr/bin/pki", mode = "755" },
-    { source = "../../README.md", dest = "/usr/share/doc/pki-client/README.md", mode = "644", doc = true },
-    { source = "../../LICENSE", dest = "/usr/share/doc/pki-client/LICENSE", mode = "644", doc = true },
-]

--- a/install.sh
+++ b/install.sh
@@ -4,66 +4,31 @@ set -euo pipefail
 # ============================================================================
 # PKI-Client Installer / Upgrader / Uninstaller
 #
-# Detects the host distro and installs the appropriate native package:
-#   Debian/Ubuntu  -> .deb  (installed with dpkg)
-#   RHEL/Fedora/etc -> .rpm (installed with dnf/yum)
+# Downloads the statically-linked musl binary (single artifact, zero runtime
+# deps). Works on any x86_64 Linux distro — Debian, Ubuntu, RHEL, Rocky,
+# Alma, Fedora, Alpine — because the binary depends on nothing at runtime.
 #
 # Install:     curl -fsSL https://raw.githubusercontent.com/rayketcham-lab/PKI-Client/main/install.sh | sudo bash
 # Upgrade:     curl -fsSL .../install.sh | sudo bash -s -- upgrade
 # Uninstall:   curl -fsSL .../install.sh | sudo bash -s -- uninstall
-# Pin version: curl -fsSL .../install.sh | sudo bash -s -- v0.9.1
+# Pin version: curl -fsSL .../install.sh | sudo bash -s -- v0.9.3
 # ============================================================================
 
 REPO="rayketcham-lab/PKI-Client"
 ACTION="${1:-install}"
-
-# ── Detect package format ────────────────────────────────────────────────────
-
-detect_pkg_format() {
-    if command -v dpkg >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
-        echo "deb"
-    elif command -v rpm >/dev/null 2>&1 && (command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1); then
-        echo "rpm"
-    else
-        echo "unsupported"
-    fi
-}
-
-PKG_FORMAT="$(detect_pkg_format)"
+INSTALL_PATH="${PKI_INSTALL_PATH:-/usr/local/bin/pki}"
 
 # ── Uninstall ────────────────────────────────────────────────────────────────
 
 if [[ "$ACTION" == "uninstall" ]]; then
     echo "PKI-Client Uninstaller"
     echo "======================"
-
-    case "$PKG_FORMAT" in
-        deb)
-            if dpkg -s pki-client >/dev/null 2>&1; then
-                apt-get remove -y pki-client
-            else
-                echo "pki-client is not installed (dpkg)."
-            fi
-            ;;
-        rpm)
-            if rpm -q pki-client >/dev/null 2>&1; then
-                if command -v dnf >/dev/null 2>&1; then
-                    dnf remove -y pki-client
-                else
-                    yum remove -y pki-client
-                fi
-            else
-                echo "pki-client is not installed (rpm)."
-            fi
-            ;;
-        *)
-            echo "ERROR: Unsupported distro — no dpkg or rpm detected."
-            exit 1
-            ;;
-    esac
-
-    echo ""
-    echo "Done! pki-client has been uninstalled."
+    if [[ -f "$INSTALL_PATH" ]]; then
+        rm -f "$INSTALL_PATH"
+        echo "Removed $INSTALL_PATH"
+    else
+        echo "$INSTALL_PATH not present — nothing to remove."
+    fi
     exit 0
 fi
 
@@ -77,7 +42,7 @@ OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 
 if [[ "$OS" != "linux" ]]; then
-    echo "ERROR: Unsupported OS: $OS (Linux only for pre-built installers)"
+    echo "ERROR: Unsupported OS: $OS (Linux only)"
     exit 1
 fi
 
@@ -88,13 +53,6 @@ case "$ARCH" in
         exit 1
         ;;
 esac
-
-if [[ "$PKG_FORMAT" == "unsupported" ]]; then
-    echo "ERROR: No supported package manager found."
-    echo "Supported: dpkg+apt (Debian/Ubuntu) or rpm+dnf/yum (RHEL/Fedora/Rocky/Alma)."
-    echo "Download assets manually from: https://github.com/$REPO/releases"
-    exit 1
-fi
 
 # Resolve version
 if [[ "$ACTION" == "upgrade" || "$ACTION" == "install" ]]; then
@@ -113,24 +71,20 @@ if [[ "$VERSION" == "latest" ]]; then
 fi
 
 VERSION_NUM="${VERSION#v}"
-
-case "$PKG_FORMAT" in
-    deb) FILENAME="pki-client_${VERSION_NUM}_amd64.deb" ;;
-    rpm) FILENAME="pki-client-${VERSION_NUM}-1.x86_64.rpm" ;;
-esac
-
+FILENAME="pki-${VERSION_NUM}-linux-x86_64-musl"
 URL="https://github.com/$REPO/releases/download/${VERSION}/${FILENAME}"
 CHECKSUM_URL="https://github.com/$REPO/releases/download/${VERSION}/SHA256SUMS.txt"
 
 echo "Version:  $VERSION"
-echo "Package:  $FILENAME ($PKG_FORMAT)"
+echo "Asset:    $FILENAME"
+echo "Install:  $INSTALL_PATH"
 echo ""
 
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
 
 echo "Downloading $FILENAME..."
-if ! curl -fSL -o "$TMPDIR/$FILENAME" "$URL"; then
+if ! curl -fSL -o "$WORKDIR/$FILENAME" "$URL"; then
     echo "ERROR: Download failed from $URL"
     exit 1
 fi
@@ -138,41 +92,32 @@ fi
 # ── Verify checksum ──────────────────────────────────────────────────────────
 
 echo "Verifying checksum..."
-curl -fsSL -o "$TMPDIR/SHA256SUMS.txt" "$CHECKSUM_URL" 2>/dev/null || true
-if [[ -f "$TMPDIR/SHA256SUMS.txt" ]]; then
-    EXPECTED="$(grep "$FILENAME" "$TMPDIR/SHA256SUMS.txt" | cut -d' ' -f1)"
-    ACTUAL="$(sha256sum "$TMPDIR/$FILENAME" | cut -d' ' -f1)"
-    if [[ "$EXPECTED" == "$ACTUAL" ]]; then
-        echo "Checksum: OK"
-    else
-        echo "ERROR: Checksum mismatch!"
-        echo "  Expected: $EXPECTED"
-        echo "  Got:      $ACTUAL"
-        exit 1
-    fi
-else
-    echo "Checksum: skipped (no SHA256SUMS.txt)"
+if ! curl -fsSL -o "$WORKDIR/SHA256SUMS.txt" "$CHECKSUM_URL"; then
+    echo "ERROR: SHA256SUMS.txt download failed — refusing to install unverified binary."
+    exit 1
 fi
+
+EXPECTED="$(grep " ${FILENAME}\$" "$WORKDIR/SHA256SUMS.txt" | cut -d' ' -f1)"
+if [[ -z "$EXPECTED" ]]; then
+    echo "ERROR: $FILENAME not listed in SHA256SUMS.txt — refusing to install."
+    exit 1
+fi
+ACTUAL="$(sha256sum "$WORKDIR/$FILENAME" | cut -d' ' -f1)"
+if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+    echo "ERROR: Checksum mismatch!"
+    echo "  Expected: $EXPECTED"
+    echo "  Got:      $ACTUAL"
+    exit 1
+fi
+echo "Checksum: OK"
 
 # ── Install ──────────────────────────────────────────────────────────────────
 
-echo "Installing $FILENAME..."
-case "$PKG_FORMAT" in
-    deb)
-        dpkg -i "$TMPDIR/$FILENAME" || {
-            echo "dpkg reported unmet deps — attempting apt-get -f install"
-            apt-get install -f -y
-        }
-        ;;
-    rpm)
-        if command -v dnf >/dev/null 2>&1; then
-            dnf install -y "$TMPDIR/$FILENAME"
-        else
-            yum install -y "$TMPDIR/$FILENAME"
-        fi
-        ;;
-esac
+echo "Installing to $INSTALL_PATH..."
+chmod +x "$WORKDIR/$FILENAME"
+mkdir -p "$(dirname "$INSTALL_PATH")"
+mv "$WORKDIR/$FILENAME" "$INSTALL_PATH"
 
 echo ""
-echo "Done! Installed pki-client $VERSION"
-pki --version 2>/dev/null || echo "(pki binary not yet on PATH in this shell; open a new shell or check /usr/bin/pki)"
+echo "Done! Installed pki $VERSION"
+"$INSTALL_PATH" --version


### PR DESCRIPTION
## Summary

- Drop `.deb` + `.rpm` packaging in favor of a single bare static musl binary
- One release asset: `pki-${VERSION}-linux-x86_64-musl` — the binary IS the installer (drop into PATH)
- `install.sh` becomes distro-agnostic (download + verify + chmod + mv)

## Why

The pki binary is fully static (musl), already ran identically on every Linux distro. Wrapping it in two distro-specific packages produced byte-identical `/usr/bin/pki` in both `.deb` and `.rpm`, doubled the CI surface, and forced users to think about which wrapper their distro speaks. The binary itself is the installer.

## Files

- `.github/workflows/release.yml` — drop cargo-deb/cargo-generate-rpm install, .deb/.rpm build, dpkg-deb/rpm smoke-tests. Sign + sha256 + attest + release just the binary.
- `crates/pki-client/Cargo.toml` — drop `[package.metadata.deb]` + `[package.metadata.generate-rpm]`.
- `install.sh` — bare-binary downloader. Now refuses install on missing checksum (previously soft-skipped — security bug).
- `README.md` — one-line install + manual path.

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] TOML/YAML/shell syntax valid (toml.loads / yaml.safe_load / `bash -n` / shellcheck)
- [x] `grep -nE '\.deb|\.rpm|dpkg|rpm -|cargo-deb|cargo-generate-rpm'` clean (only legitimate gh CLI installer refs remain)
- [ ] CI green on this branch
- [ ] After merge: destructive retag of v0.9.3 (delete release + tag, retag at new commit) — pending explicit go-ahead

Generated with Claude Code